### PR TITLE
fix broken links in homepage

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -25,8 +25,8 @@ More detailed documentation can be accessed using the ☰ menu in the top left c
 
 ## Key internal docs links
 
- - [Hardware](/hw/overview)
- - [ROS 2 API](/api/ros2/)
+ - [Hardware](hw/overview)
+ - [ROS 2 API](api/ros2/)
 
 ## Useful external links
 


### PR DESCRIPTION
The previous links were returning 404 errors due to being absolute links

Signed-off-by: Alberto Soragna <alberto.soragna@gmail.com>