### PR TITLE
Remove Unicode circles and fix yellow indicator text

### DIFF
--- a/docs/hw/electrical.md
+++ b/docs/hw/electrical.md
@@ -49,16 +49,16 @@ The **USB/BLE toggle** routes the robot's single USB Host connection either to t
 This module can be used to interact with the [iRobot Coding app](https://code.irobot.com).
 
 ## Indicators
-### 🟠 Orange Indicator
+### Orange Indicator
 The **orange indicator (D3)** is illuminated when the USB-C® port is powering a downstream device, whether or not a data connection is being made.
 
-### 🟡 Yellow Indicator
-The **yellow indicator (D2)** is illuminated when the robot's internal 5 V bus is enabled. There is an error if this LED is extinguished.
+### Yellow Indicator
+The **yellow indicator (D2)** is illuminated when the robot's internal 5 V bus is enabled. There is a hardware error if this LED is extinguished while the green indicator is illuminated.
 
-### 🟢 Green Indicator
+### Green Indicator
 The **green indicator (D300)** is illuminated when the robot's battery is switched on.
 
-### 🔵 Blue Indicator
+### Blue Indicator
 The **blue indicator (D6)** is illuminated when the BLE radio is turned on. It flashes when it is connected to a host.
 
 [^1]: USB-C® is a trademark of USB Implementers Forum. 


### PR DESCRIPTION
Removed colored circles since they are from different versions of the Unicode standard and also are not guaranteed to properly render. Also fixed text on yellow indicator. This fixes #24 