### PR TITLE
add xml-config page and move boards setup down one level

### DIFF
--- a/docs/examples/create3_examples.md
+++ b/docs/examples/create3_examples.md
@@ -1,0 +1,3 @@
+# iRobot® Create® 3 Examples
+
+The [create3_examples](https://github.com/iRobotEducation/create3_examples) Github repository contains examples of C++ and Python applications that can be used to control a Create® 3 robot with ROS 2 and develop your navigation application.

--- a/docs/examples/overview.md
+++ b/docs/examples/overview.md
@@ -1,4 +1,0 @@
-# iRobot® Create® 3 Examples
-
-This section includes simple examples for controlling and receiving feedback from the robot.
-More detailed examples can be found in a dedicated [Github repository](https://github.com/iRobotEducation/create3_examples).

--- a/docs/setup/xml-config.md
+++ b/docs/setup/xml-config.md
@@ -35,7 +35,7 @@ A ROS 2 process will automatically use all the interfaces that were available wh
 
 #### Disable Multicast
 
-Some networks (e.g. corporate WiFi) may block the multicast packets used by ROS 2 by default.
+Some networks (e.g., academic or corporate Wi-Fi) may block the multicast packets used by ROS 2 by default.
 The following XML profile can be used on your laptop (or compute board) to force using unicast and directly connect to the IP address of your robot.
 
 The file must be edited replacing `ROBOT_IP` with the actual IP value.

--- a/docs/setup/xml-config.md
+++ b/docs/setup/xml-config.md
@@ -1,0 +1,117 @@
+# ROS 2 Network Configuration
+
+The ROS 2 DDS middleware allows advanced network configurations.
+This page contains some examples that may be useful when interacting with the iRobot® Create® 3.
+
+!!! important 
+    Depending on the ROS 2 RMW used, the syntax for configuring the network will be different. We recommend to visit the RMW vendor documentation for more details.
+
+You can choose a RMW implementation on your machine using
+
+```sh
+export RMW_IMPLEMENTATION=name-of-the-rmw
+```
+
+On the robot the same can be controlled through the Create® 3 webserver.
+
+!!! important 
+    Always make sure that all the ROS 2 processes you are using have selected the same RMW implementation.
+
+## Fast-DDS
+
+Fast-DDS allows to specify DDS configuration through an XML file.
+In order to apply a configuration, the path to the XML file must be provided through the following environment variable:
+
+```sh
+export FASTRTPS_DEFAULT_PROFILES_FILE=/path/to/the/xml/profile 
+```
+
+Detailed network configurations are described in the [Fast-DDS documentation](https://fast-dds.docs.eprosima.com/en/latest/).
+
+#### Multiple Network Interfaces
+
+Fast-DDS supports multiple network interfaces out of the box.
+A ROS 2 process will automatically use all the interfaces that were available when it started (it will not use network interfaces activated while the process was already running).
+
+#### Disable Multicast
+
+Some networks (e.g. corporate WiFi) may block the multicast packets used by ROS 2 by default.
+The following XML profile can be used on your laptop (or compute board) to force using unicast and directly connect to the IP address of your robot.
+
+The file must be edited replacing `ROBOT_IP` with the actual IP value.
+```
+<?xml version="1.0" encoding="UTF-8" ?>
+<profiles xmlns="http://www.eprosima.com/XMLSchemas/fastRTPS_Profiles">
+   <participant profile_name="unicast_connection" is_default_profile="true">
+       <rtps>
+           <builtin>
+               <metatrafficUnicastLocatorList>
+                   <locator/>
+               </metatrafficUnicastLocatorList>
+               <initialPeersList>
+                   <locator>
+                       <udpv4>
+                           <address>ROBOT_IP</address>
+                       </udpv4>
+                   </locator>
+               </initialPeersList>
+           </builtin>
+       </rtps>
+   </participant>
+</profiles>
+```
+
+## CycloneDDS
+
+CycloneDDS allows to specify DDS configuration through an XML file.
+In order to apply a configuration, the path to the XML file must be provided through the following environment variable:
+
+```sh
+export CYCLONEDDS_URI=/path/to/the/xml/profile 
+```
+
+Detailed network configurations are described in the [CycloneDDS documentation](https://github.com/eclipse-cyclonedds/cyclonedds#configuration).
+
+#### Multiple Network Interfaces
+
+This feature requires CycloneDDS version 0.8.0 or higher.
+Use the following XML profile specifying the name of all the network interfaces you want to use.
+For example `usb0` and `wlan0` in this example.
+
+```
+<CycloneDDS>
+   <Domain>
+     <General>
+        <NetworkInterfaceAddress>usb0,wlan0</NetworkInterfaceAddress>
+    </General>
+   </Domain>
+</CycloneDDS>
+```
+
+Note that the specified network interfaces must be already active when the ROS 2 process is started.
+
+#### Disable Multicast
+
+Some networks (e.g. corporate WiFi) may block the multicast packets used by ROS 2 by default.
+The following XML profile can be used on your laptop (or compute board) to force using unicast and directly connect to the IP address of your robot.
+
+The file must be edited replacing `${ROBOT_IP}` with the actual IP value, or exporting the value as an environment variable.
+
+```
+<CycloneDDS>
+  <Domain>
+    <Id>any</Id>
+    <General>
+      <NetworkInterfaceAddress>auto</NetworkInterfaceAddress>
+      <AllowMulticast>false</AllowMulticast>
+      <EnableMulticastLoopback>true</EnableMulticastLoopback>
+    </General>
+    <Discovery>
+      <ParticipantIndex>0</ParticipantIndex>
+      <Peers>
+        <Peer Address="${ROBOT_IP}:7410"/>
+      </Peers>
+    </Discovery>
+  </Domain>
+</CycloneDDS>
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -33,8 +33,10 @@ nav:
     - Setup:
       - Connect to Wi-Fi: setup/provision.md
       - Multi-Robot Setup: setup/multi-robot.md
-      - ROS 2 on an NVIDIA Jetson: setup/jetson.md
-      - ROS 2 on a Pi 4: setup/pi4.md
+      - ROS 2 Network Config: setup/xml-config.md
+      - Setup Compute Boards:
+        - ROS 2 on an NVIDIA Jetson: setup/jetson.md
+        - ROS 2 on a Pi 4: setup/pi4.md
     - APIs:
       - ROS 2 Interface: api/ros2.md
       - Docking: api/docking.md
@@ -47,8 +49,8 @@ nav:
     - Simulator:
       - Using the Simulator: sim/setup.md
     - Software Examples:
-      - Overview: examples/overview.md
       - Driving via CLI: examples/driving-cli.md
+      - Navigation Apps: examples/create3_examples.md
     - Software Releases:
       - Overview: releases/overview.md
       - G.1.1: releases/g_1_1.md


### PR DESCRIPTION
Signed-off-by: Alberto Soragna <alberto.soragna@gmail.com>

This PR contains the following changes:
 - add network configuration page
 - move the RPi and jetson setup pages under a "Setup Compute Boards" level to distinguish them from the robot setup.
 - rephrase a little bit the Create 3 examples stub page