### PR TITLE
Add documentation for pi to run multi interface cyclone file and docu…

### DIFF
--- a/docs/api/ros2.md
+++ b/docs/api/ros2.md
@@ -29,6 +29,7 @@ $ ros2 topic list -t
 /rosout [rcl_interfaces/msg/Log]
 /slip_status [irobot_create_msgs/msg/SlipStatus]
 /stop_status [irobot_create_msgs/msg/StopStatus]
+/tf [tf2_msgs/msg/TFMessage]
 /tf_static [tf2_msgs/msg/TFMessage]
 /wheel_status [irobot_create_msgs/msg/WheelStatus]
 /wheel_ticks [irobot_create_msgs/msg/WheelTicks]

--- a/docs/setup/jetson.md
+++ b/docs/setup/jetson.md
@@ -114,10 +114,10 @@ The recommended way to run ROS2 on Jetson is to use pre-built Docker container i
 
         export CYCLONEDDS_URI='<CycloneDDS><Domain><General><NetworkInterfaceAddress>l4tbr0</NetworkInterfaceAddress></General></Domain></CycloneDDS>'
     !!! attention
-        **If you are using CycloneDDS (Galactic default) and want the Jetson to talk to the robot over USB and a laptop via wifi, you have a multiple interface situation.**
+        **If you are using CycloneDDS (Galactic default) and want the Jetson to talk to the robot over USB and a laptop via Wi-Fi, you will need to take extra steps to use multiple interfaces.**
         **You will need to export a path on the Jetson to an xml config file that registers those interfaces in the CYCLONEDDS_URI.**
         **See [CycloneDDS Multiple Network Interfaces](../xml-config/#cyclonedds).**
-        **Note the differences in Jetson USB and Wifi interface names from the documentation.**
+        **Note the differences in Jetson USB and Wi-Fi interface names from the documentation.**
 
 4. Check to ensure Create® 3 topics appear
 

--- a/docs/setup/jetson.md
+++ b/docs/setup/jetson.md
@@ -114,7 +114,7 @@ The recommended way to run ROS2 on Jetson is to use pre-built Docker container i
 
         export CYCLONEDDS_URI='<CycloneDDS><Domain><General><NetworkInterfaceAddress>l4tbr0</NetworkInterfaceAddress></General></Domain></CycloneDDS>'
     !!! attention
-        **If you are using CycloneDDS (Galactic default) and want the Jetson to talk to the robot over USB and a laptop via wifi, you have a multi interface situation.**
+        **If you are using CycloneDDS (Galactic default) and want the Jetson to talk to the robot over USB and a laptop via wifi, you have a multiple interface situation.**
         **You will need to export a path on the Jetson to an xml config file that registers those interfaces in the CYCLONEDDS_URI.**
         **See [CycloneDDS Multiple Network Interfaces](../xml-config/#cyclonedds).**
         **Note the differences in Jetson USB and Wifi interface names from the documentation.**
@@ -126,6 +126,7 @@ The recommended way to run ROS2 on Jetson is to use pre-built Docker container i
     You should get
 
         /battery_state
+        /cmd_audio
         /cmd_lightring
         /cmd_vel
         /dock
@@ -143,6 +144,7 @@ The recommended way to run ROS2 on Jetson is to use pre-built Docker container i
         /stop_status
         /tf
         /tf_static
+        /wheel_status
         /wheel_ticks
         /wheel_vels
 

--- a/docs/setup/jetson.md
+++ b/docs/setup/jetson.md
@@ -75,11 +75,11 @@ It is highly recommended to read through the getting started document for your N
                 TX packets 1644  bytes 213306 (213.3 KB)
                 TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
 
-!!! warning
-    Be sure that the [USB/BLE toggle on the robot's adapter board](../../hw/electrical/#adapter-board-overview) is set to the USB position.
+    !!! warning
+        Be sure that the [USB/BLE toggle on the robot's adapter board](../../hw/electrical/#adapter-board-overview) is set to the USB position.
 
-!!! note
-    If you ever want to stop using the Jetson device for Create® 3 and re-enable the original USB Device Mode feature (so that you can connect to your Windows PC in headless style), you can simply remove the flag file, or execute the following.
+    !!! note
+        If you ever want to stop using the Jetson device for Create® 3 and re-enable the original USB Device Mode feature (so that you can connect to your Windows PC in headless style), you can simply remove the flag file, or execute the following.
 
         sudo mv /opt/nvidia/l4t-usb-device-mode/IP_ADDRESS_FOR_CREATE3_ROBOT.conf /opt/nvidia/l4t-usb-device-mode/IP_ADDRESS_FOR_CREATE3_ROBOT.conf.bak
 
@@ -113,6 +113,11 @@ The recommended way to run ROS2 on Jetson is to use pre-built Docker container i
 3. Set the default network interface by setting Cyclone DDS configuration.
 
         export CYCLONEDDS_URI='<CycloneDDS><Domain><General><NetworkInterfaceAddress>l4tbr0</NetworkInterfaceAddress></General></Domain></CycloneDDS>'
+    !!! attention
+        **If you are using CycloneDDS (Galactic default) and want the Jetson to talk to the robot over USB and a laptop via wifi, you have a multi interface situation.**
+        **You will need to export a path on the Jetson to an xml config file that registers those interfaces in the CYCLONEDDS_URI.**
+        **See [CycloneDDS Multiple Network Interfaces](../xml-config/#cyclonedds).**
+        **Note the differences in Jetson USB and Wifi interface names from the documentation.**
 
 4. Check to ensure Create® 3 topics appear
 

--- a/docs/setup/jetson.md
+++ b/docs/setup/jetson.md
@@ -114,8 +114,8 @@ The recommended way to run ROS2 on Jetson is to use pre-built Docker container i
 
         export CYCLONEDDS_URI='<CycloneDDS><Domain><General><NetworkInterfaceAddress>l4tbr0</NetworkInterfaceAddress></General></Domain></CycloneDDS>'
     !!! attention
-        **If you are using CycloneDDS (Galactic default) and want the Jetson to talk to the robot over USB and a laptop via Wi-Fi, you will need to take extra steps to use multiple interfaces.**
-        **You will need to export a path on the Jetson to an xml config file that registers those interfaces in the CYCLONEDDS_URI.**
+        **If you are using CycloneDDS (Galactic default) and want the Jetson to talk to the robot over USB and a laptop via Wi-Fi, you will need to take extra steps to setup CycloneDDS to use multiple interfaces.**
+        **You will need to create a CycloneDDS XML configuration file with both USB and Wi-Fi interfaces and then set the CYCLONEDDS_URI environment variable to its path.**
         **See [CycloneDDS Multiple Network Interfaces](../xml-config/#cyclonedds).**
         **Note the differences in Jetson USB and Wi-Fi interface names from the documentation.**
 

--- a/docs/setup/pi4.md
+++ b/docs/setup/pi4.md
@@ -5,12 +5,12 @@
     **These directions are written for someone with experience with embedded Linux and basic embedded computers.**
 It is highly recommended to read through the following documents before beginning:
 
-* [How to install Ubuntu Server on your Raspberry Pi](https://ubuntu.com/tutorials/how-to-install-ubuntu-on-your-raspberry-pi) - official Canonical documentation
-* [Installing ROS 2 on Ubuntu Linux](https://docs.ros.org/en/galactic/Installation/Ubuntu-Install-Binary.html) - official Open Robotics documentation
+* [How to install Ubuntu Server on your Raspberry Pi](https://ubuntu.com/tutorials/how-to-install-ubuntu-on-your-raspberry-pi)[^1] - official Canonical documentation
+* [Installing ROS 2 on Ubuntu Linux](https://docs.ros.org/en/galactic/Installation/Ubuntu-Install-Binary.html)[^1] - official Open Robotics documentation
 
 ## Step-by-step
 
-1. Download [Ubuntu® Server 20.04 64-bit](https://ubuntu.com/download/raspberry-pi) and write onto a microSD card.
+1. Download [Ubuntu® Server 20.04 64-bit](https://ubuntu.com/download/raspberry-pi)[^1] and write onto a microSD card.
 1. In the system-boot partition, edit usercfg.txt and add `dtoverlay=dwc2,dr_mode=peripheral`. For convenience, [here's a copy of this file](data/usercfg.txt).
 1. In the system-boot partition, edit cmdline.txt to add `modules-load=dwc2,g_ether` after `rootwait`. For convenience, [here's a copy of this file](data/cmdline.txt).
 1. In the system-boot partition, edit network-config to optionally add information about your Wi-Fi connection, and also add the following under `ethernets`
@@ -24,8 +24,8 @@ It is highly recommended to read through the following documents before beginnin
     Note that the robot uses the default IP address of 192.168.186.2 on its usb0 interface.
     Please note also that after initial boot, editing `network-config` in the boot partition will not do anything; instead, the file to edit can be found at `/etc/netplan/50-cloud-init.yaml`.
 
-1. If you would like your Raspberry Pi® 4 to communicate with the Create® 3 over its USB-C® port (and not just to power it), be sure that the [USB/BLE toggle on the robot's adapter board](../../hw/electrical/#adapter-board-overview) is set to the USB position.
-1. Insert the microSD card into the Raspberry Pi® 4, and then use a USB-C® to USB-C® cable to connect the Raspberry Pi® 4 to the Create® 3.
+1. If you would like your Raspberry Pi® 4[^3] to communicate with the Create® 3 over its USB-C®[^2] port (and not just to power it), be sure that the [USB/BLE toggle on the robot's adapter board](../../hw/electrical/#adapter-board-overview) is set to the USB position.
+1. Insert the microSD card into the Raspberry Pi® 4[^3], and then use a USB-C®[^2] to USB-C®[^2] cable to connect the Raspberry Pi® 4[^3] to the Create® 3.
 A photo of this connection can be found [here](../../hw/hookup/#raspberry-pi-4).
 The first boot may take a few minutes. (It may help to have a monitor and keyboard set up in case of any trouble on the first boot.)
 
@@ -65,9 +65,10 @@ The first boot may take a few minutes. (It may help to have a monitor and keyboa
 A full Create® 3 API description can be found [here](../../api/ros2).
 
     !!! attention
-        **If you are using CycloneDDS (Galactic default), your Pi is running with multiple network interfaces (usb0 to talk to robot and wlan0 to talk to laptop).**
-        **You will need to export a path on the Pi to an xml config file that registers those interfaces in the CYCLONEDDS_URI.**
+        **If you are using CycloneDDS (Galactic default), your Raspberry Pi® may be running with multiple network interfaces (usb0 to talk to robot and wlan0 to talk to laptop).**
+        **You will need to export a path on the Raspberry Pi® to an xml config file that registers those interfaces in the CYCLONEDDS_URI.**
         **See [CycloneDDS Multiple Network Interfaces](../xml-config/#cyclonedds).**
 
-**
-<sub><sup>Ubuntu is a registered trademark of Canonical Ltd. USB-C® is a trademark of USB Implementers Forum. Raspberry Pi is a trademark of Raspberry Pi Trading. All other trademarks mentioned are the property of their respective owners.</sup></sub>
+[^1]: Ubuntu is a registered trademark of Canonical Ltd.
+[^2]: USB-C® is a trademark of USB Implementers Forum.
+[^3]: Raspberry Pi® is a trademark of Raspberry Pi Trading. All other trademarks mentioned are the property of their respective owners.

--- a/docs/setup/pi4.md
+++ b/docs/setup/pi4.md
@@ -63,5 +63,10 @@ The first boot may take a few minutes. (It may help to have a monitor and keyboa
 
 1. Log out and log back in. Once you do, test things out with a `ros2 topic list`.
 A full Create® 3 API description can be found [here](../../api/ros2).
+!!! attention
+    **If you are using CycloneDDS (Galactic default), your Pi is running with multiple network interfaces (usb0 to talk to robot and wlan0 to talk to laptop).**
+    **You will need to export a path on the Pi to an xml config file that registers those interfaces in the CYCLONEDDS_URI.**
+    **See [CycloneDDS Multiple Network Interfaces](../xml-config/#cyclonedds).**
 
+**
 <sub><sup>Ubuntu is a registered trademark of Canonical Ltd. USB-C® is a trademark of USB Implementers Forum. Raspberry Pi is a trademark of Raspberry Pi Trading. All other trademarks mentioned are the property of their respective owners.</sup></sub>

--- a/docs/setup/pi4.md
+++ b/docs/setup/pi4.md
@@ -63,10 +63,11 @@ The first boot may take a few minutes. (It may help to have a monitor and keyboa
 
 1. Log out and log back in. Once you do, test things out with a `ros2 topic list`.
 A full Create® 3 API description can be found [here](../../api/ros2).
-!!! attention
-    **If you are using CycloneDDS (Galactic default), your Pi is running with multiple network interfaces (usb0 to talk to robot and wlan0 to talk to laptop).**
-    **You will need to export a path on the Pi to an xml config file that registers those interfaces in the CYCLONEDDS_URI.**
-    **See [CycloneDDS Multiple Network Interfaces](../xml-config/#cyclonedds).**
+
+    !!! attention
+        **If you are using CycloneDDS (Galactic default), your Pi is running with multiple network interfaces (usb0 to talk to robot and wlan0 to talk to laptop).**
+        **You will need to export a path on the Pi to an xml config file that registers those interfaces in the CYCLONEDDS_URI.**
+        **See [CycloneDDS Multiple Network Interfaces](../xml-config/#cyclonedds).**
 
 **
 <sub><sup>Ubuntu is a registered trademark of Canonical Ltd. USB-C® is a trademark of USB Implementers Forum. Raspberry Pi is a trademark of Raspberry Pi Trading. All other trademarks mentioned are the property of their respective owners.</sup></sub>

--- a/docs/setup/provision.md
+++ b/docs/setup/provision.md
@@ -11,6 +11,8 @@ This can be found in the Application &rarr; Configuration menu in the Create® 3
 The default RMW for ROS 2 Galactic is Cyclone DDS.
 Be sure to click "save" after making any changes, and then restart the application.
 
+See [ROS 2 Network Config](xml-config.md) for more information about RMW specific choices and configuration requirements.
+
 ## Using Multiple Robots
 
 !!! important 

--- a/docs/setup/xml-config.md
+++ b/docs/setup/xml-config.md
@@ -90,6 +90,18 @@ For example `usb0` and `wlan0` in this example.
 
 Note that the specified network interfaces must be already active when the ROS 2 process is started.
 
+!!! attention
+    **If the robot is running with a Compute Board like a [Raspberry Pi®](../pi4) or an [NVIDIA® Jetson™](../jetson) connected, then the robot is using a multiple interface CycloneDDS config file to communicate both over usb0 and wlan0.**
+    **We have found that with CycloneDDS version 0.8.1, for an Ubuntu laptop to see the robot topics with CycloneDDS when running multiple interfaces, the laptop must use the configuration option:**
+```
+<CycloneDDS>
+   <Domain>
+     <General>
+        <DontRoute>true</DontRoute>
+    </General>
+   </Domain>
+</CycloneDDS>
+```
 #### Disable Multicast
 
 Some networks (e.g. corporate WiFi) may block the multicast packets used by ROS 2 by default.

--- a/docs/setup/xml-config.md
+++ b/docs/setup/xml-config.md
@@ -91,7 +91,7 @@ For example `usb0` and `wlan0` in this example.
 Note that the specified network interfaces must be already active when the ROS 2 process is started.
 
 !!! attention
-    **If the robot is running with a Compute Board like a [Raspberry Pi®](../pi4) or an [NVIDIA® Jetson™](../jetson) connected, then the robot is using a multiple interface CycloneDDS config file to communicate both over usb0 and wlan0.**
+    **If the robot is running with a Compute Board like a [Raspberry Pi®](../pi4) or an [NVIDIA® Jetson™](../jetson) connected via USB, then the robot is using a multiple interface CycloneDDS config file to communicate both over usb0 and wlan0.**
     **We have found that with CycloneDDS version 0.8.1, for an Ubuntu laptop to see the robot topics with CycloneDDS when running multiple interfaces, the laptop must use the configuration option:**
 ```
 <CycloneDDS>


### PR DESCRIPTION
- Add documentation for pi to run multi interface cyclone file
- Document don't route laptop config to work with multiple interface
Hopefully default instruction flow for pi setup now takes people through the multi config setup that should yield them a ROS 2 topic list success for the multi-interface case.