### PR TITLE
Adding directions for install on a simple Ubuntu 20.04 machine

### DIFF
--- a/docs/setup/compute-ntp.md
+++ b/docs/setup/compute-ntp.md
@@ -2,7 +2,7 @@
 
 ## Why should I do this?
 
-ROS 2 is dependent upon synchronized clocks between nodes to have all data in the same reference time.
+ROS 2[^1] is dependent upon synchronized clocks between nodes to have all data in the same reference time.
 When the Create® 3 is publishing on topics, it is publishing its data with the timestamp of its system clock, which synchronizes with an NTP server.
 If the Create® 3's Wi-Fi is connected to a network with internet connection, it will sync to a global time NTP server.
 The Create® 3 NTP config is also set to listen for servers on USB IP address 192.168.186.1 and 192.168.186.3.
@@ -51,3 +51,5 @@ If your Create® 3 and compute board have an internet connection, this is not re
 
         user.notice ntpd: ntpd: reply from 192.168.186.3: delay ### is too high, ignoring
     If this happens, simply restart the robot (not just the application) via the webserver over the USB network connection.
+
+[^1]: ROS 2 is governed by Open Robotics

--- a/docs/setup/multi-robot.md
+++ b/docs/setup/multi-robot.md
@@ -8,7 +8,7 @@ Note that if you have multiple robots, but they are not on the same network, the
 
 ## Basic Concepts on ROS 2 Communication
 
-ROS 2 communication is based on the underlying DDS middleware.
+ROS 2[^1] communication is based on the underlying DDS middleware.
 After two ROS processes discover each other, they will automatically start to communicate if their topics, services, or actions match.
 
 The default discovery protocol used by ROS 2 is based on broadcast.
@@ -90,3 +90,5 @@ Note that a ROS 2 process can only use one domain ID at a time.
 If needed you can always have multiple robots under the same domain ID and then also add namespaces to prevent them from communicating.
 
 Using a custom ROS 2 domain ID for your robots is the recommended solution when you have a large number of robots and you want your tools to communicate only with a subset of them.
+
+[^1]: ROS 2 is governed by Open Robotics

--- a/docs/setup/pi4.md
+++ b/docs/setup/pi4.md
@@ -37,7 +37,7 @@ The first boot may take a few minutes. (It may help to have a monitor and keyboa
         sudo update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
         export LANG=en_US.UTF-8
 
-1. Then, execute the following commands:
+1. Then, execute the following commands to install ROS 2[^4]:
 
         sudo apt update && sudo apt install -y curl gnupg2 lsb-release build-essential git cmake
         sudo curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key  -o /usr/share/keyrings/ros-archive-keyring.gpg
@@ -70,3 +70,4 @@ A full Create® 3 API description can be found [here](../../api/ros2).
 [^1]: Ubuntu is a registered trademark of Canonical Ltd.
 [^2]: USB-C® is a trademark of USB Implementers Forum.
 [^3]: Raspberry Pi® is a trademark of Raspberry Pi Trading. All other trademarks mentioned are the property of their respective owners.
+[^4]: ROS 2 is governed by Open Robotics

--- a/docs/setup/provision.md
+++ b/docs/setup/provision.md
@@ -3,7 +3,7 @@
 Follow the main guide for getting started [here](https://edu.irobot.com/create3-setup).
 
 ## Select RMW Implementation
-If you are planning to use ROS 2, make sure you have selected the matching RMW implementation as the rest of the nodes in your system.
+If you are planning to use ROS 2[^1], make sure you have selected the matching RMW implementation as the rest of the nodes in your system.
 This can be found in the Application &rarr; Configuration menu in the Create® 3 robot's web server, shown in the below image.
 
 ![Application Configuration Detail](data/appconfig.png)
@@ -19,3 +19,5 @@ See [ROS 2 Network Config](xml-config.md) for more information about RMW specifi
 
 !!! important
     If you plan to use multiple Create® 3 robots connected to the same Wi-Fi network, then **you must follow the [Multi-Robot Setup documentation](multi-robot.md)**
+
+[^1]: ROS 2 is governed by Open Robotics

--- a/docs/setup/ubuntu2004.md
+++ b/docs/setup/ubuntu2004.md
@@ -9,7 +9,9 @@ These directions should work in a virtualized container within another operating
 1. If you haven't already, download and install [Ubuntu® Server 20.04 64-bit](https://releases.ubuntu.com/20.04/ubuntu-20.04.4-live-server-amd64.iso)[^1].
 
 1. Once logged in, check to ensure that you are using a UTF-8 locale by typing
+
         echo $LANG
+   and ensuring "UTF-8" is at the end of the returned string.
 
 1. Execute the following commands to install ROS 2[^2]:
 

--- a/docs/setup/ubuntu2004.md
+++ b/docs/setup/ubuntu2004.md
@@ -1,0 +1,45 @@
+# Install ROS 2 Galactic with Create 3 Messages on an Ubuntu 20.04 Machine
+
+## Before you start
+If you are running Ubuntu 20.04 natively on a machine, there is no setup required.
+These directions should work in a virtualized container within another operating system, as well.
+
+## Step-by-step
+
+1. Download and install [Ubuntu® Server 20.04 64-bit](https://releases.ubuntu.com/20.04/ubuntu-20.04.4-live-server-amd64.iso)[^1] (if you haven't already.)
+
+1. Once logged in, check to ensure that you are using a UTF-8 locale by typing
+        echo $LANG
+
+1. Execute the following commands to install ROS 2[^2]:
+
+        sudo apt update && sudo apt install -y curl gnupg2 lsb-release build-essential git cmake
+        sudo curl -ksSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key  -o /usr/share/keyrings/ros-archive-keyring.gpg
+        echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/ros2.list > /dev/null
+        sudo apt update
+        sudo apt install -y ros-galactic-ros-base python3-colcon-common-extensions python3-rosdep ros-galactic-rmw-fastrtps-cpp ros-galactic-rmw-cyclonedds-cpp ros-galactic-irobot-create-msgs
+
+        echo "source /usr/share/colcon_cd/function/colcon_cd.sh" >> ~/.bashrc
+        echo "export _colcon_cd_root=/opt/ros/galactic/" >> ~/.bashrc
+        echo "source /usr/share/colcon_argcomplete/hook/colcon-argcomplete.bash" >> ~/.bashrc
+        echo "source /opt/ros/galactic/setup.bash" >> ~/.bashrc
+
+        source ~/.bashrc
+
+1. At this point, we recommend setting your default RMW. The RMW you set here has to match the RMW on your robot, which can be found from its Application Configuration page. More detail on RMW can be found [here](../xml-config). Right now, the Create® 3 robot supports `rmw_cyclonedds_cpp` and `rmw_fastrtps_cpp`. The default for Galactic is `rmw_cyclonedds_cpp`. Depending on your robot's RMW implementation, type one of the following:
+
+        echo "export RMW_IMPLEMENTATION=rmw_cyclonedds_cpp" >> ~/.bashrc
+or
+
+        echo "export RMW_IMPLEMENTATION=rmw_fastrtps_cpp" >> ~/.bashrc
+
+1. You should now be able to test things out with a `ros2 topic list`.
+A full Create® 3 API description can be found [here](../../api/ros2).
+
+    !!! attention
+        **If you are using CycloneDDS (Galactic default), your Raspberry Pi® may be running with multiple network interfaces (usb0 to talk to robot and wlan0 to talk to laptop).**
+        **You will need to export a path on the Raspberry Pi® to an xml config file that registers those interfaces in the CYCLONEDDS_URI.**
+        **See [CycloneDDS Multiple Network Interfaces](../xml-config/#cyclonedds).**
+
+[^1]: Ubuntu is a registered trademark of Canonical Ltd.
+[^2]: ROS 2 is governed by Open Robotics

--- a/docs/setup/ubuntu2004.md
+++ b/docs/setup/ubuntu2004.md
@@ -5,6 +5,8 @@ If you are running Ubuntu 20.04 natively on your machine, there is no extra setu
 These directions should work in a virtualized container within another operating system, as well.
 Note that there might be some network setup required if in a virtualized container; for example, RMWs seem to like running in a bridged network configuration rather than a NATted one.
 
+These directions follow Open Robotics' official documentation on [Installing ROS 2 on Ubuntu Linux](https://docs.ros.org/en/galactic/Installation/Ubuntu-Install-Binary.html), and more detailed information about what the commands below do can be found there.
+
 ## Step-by-step
 
 1. If you haven't already, download and install [Ubuntu® Server 20.04 64-bit](https://releases.ubuntu.com/20.04/ubuntu-20.04.4-live-server-amd64.iso)[^1] onto your machine.
@@ -37,6 +39,7 @@ or
         echo "export RMW_IMPLEMENTATION=rmw_fastrtps_cpp" >> ~/.bashrc
 
 1. If both your computer and robot are on the same network, you should now be able to test things out with a `ros2 topic list`.
+If this does not work, please refer to [ROS 2 Network Configuration](../xml-config/) for further configuration ideas.
 A full Create® 3 API description can be found [here](../../api/ros2).
 
 [^1]: Ubuntu is a registered trademark of Canonical Ltd.

--- a/docs/setup/ubuntu2004.md
+++ b/docs/setup/ubuntu2004.md
@@ -3,10 +3,11 @@
 ## Before you start
 If you are running Ubuntu 20.04 natively on your machine, there is no extra setup required.
 These directions should work in a virtualized container within another operating system, as well.
+Note that there might be some network setup required if in a virtualized container; for example, RMWs seem to like running in a bridged network configuration rather than a NATted one.
 
 ## Step-by-step
 
-1. If you haven't already, download and install [Ubuntu® Server 20.04 64-bit](https://releases.ubuntu.com/20.04/ubuntu-20.04.4-live-server-amd64.iso)[^1].
+1. If you haven't already, download and install [Ubuntu® Server 20.04 64-bit](https://releases.ubuntu.com/20.04/ubuntu-20.04.4-live-server-amd64.iso)[^1] onto your machine.
 
 1. Once logged in, check to ensure that you are using a UTF-8 locale by typing
 

--- a/docs/setup/ubuntu2004.md
+++ b/docs/setup/ubuntu2004.md
@@ -33,13 +33,8 @@ or
 
         echo "export RMW_IMPLEMENTATION=rmw_fastrtps_cpp" >> ~/.bashrc
 
-1. You should now be able to test things out with a `ros2 topic list`.
+1. If both your computer and robot are on the same network, you should now be able to test things out with a `ros2 topic list`.
 A full Create® 3 API description can be found [here](../../api/ros2).
-
-    !!! attention
-        **If you are using CycloneDDS (Galactic default), your Raspberry Pi® may be running with multiple network interfaces (usb0 to talk to robot and wlan0 to talk to laptop).**
-        **You will need to export a path on the Raspberry Pi® to an xml config file that registers those interfaces in the CYCLONEDDS_URI.**
-        **See [CycloneDDS Multiple Network Interfaces](../xml-config/#cyclonedds).**
 
 [^1]: Ubuntu is a registered trademark of Canonical Ltd.
 [^2]: ROS 2 is governed by Open Robotics

--- a/docs/setup/ubuntu2004.md
+++ b/docs/setup/ubuntu2004.md
@@ -1,12 +1,12 @@
 # Install ROS 2 Galactic with Create 3 Messages on an Ubuntu 20.04 Machine
 
 ## Before you start
-If you are running Ubuntu 20.04 natively on a machine, there is no setup required.
+If you are running Ubuntu 20.04 natively on your machine, there is no extra setup required.
 These directions should work in a virtualized container within another operating system, as well.
 
 ## Step-by-step
 
-1. Download and install [Ubuntu® Server 20.04 64-bit](https://releases.ubuntu.com/20.04/ubuntu-20.04.4-live-server-amd64.iso)[^1] (if you haven't already.)
+1. If you haven't already, download and install [Ubuntu® Server 20.04 64-bit](https://releases.ubuntu.com/20.04/ubuntu-20.04.4-live-server-amd64.iso)[^1].
 
 1. Once logged in, check to ensure that you are using a UTF-8 locale by typing
         echo $LANG

--- a/docs/setup/xml-config.md
+++ b/docs/setup/xml-config.md
@@ -1,9 +1,9 @@
 # ROS 2 Network Configuration
 
-The ROS 2 DDS middleware allows advanced network configurations.
+The ROS 2[^1] DDS middleware allows advanced network configurations.
 This page contains some examples that may be useful when interacting with the iRobot® Create® 3.
 
-!!! important 
+!!! important
     Depending on the ROS 2 RMW used, the syntax for configuring the network will be different. We recommend to visit the RMW vendor documentation for more details.
 
 You can choose a RMW implementation on your machine using
@@ -14,7 +14,7 @@ export RMW_IMPLEMENTATION=name-of-the-rmw
 
 On the robot the same can be controlled through the Create® 3 webserver.
 
-!!! important 
+!!! important
     Always make sure that all the ROS 2 processes you are using have selected the same RMW implementation.
 
 ## Fast-DDS
@@ -23,7 +23,7 @@ Fast-DDS allows to specify DDS configuration through an XML file.
 In order to apply a configuration, the path to the XML file must be provided through the following environment variable:
 
 ```sh
-export FASTRTPS_DEFAULT_PROFILES_FILE=/path/to/the/xml/profile 
+export FASTRTPS_DEFAULT_PROFILES_FILE=/path/to/the/xml/profile
 ```
 
 Detailed network configurations are described in the [Fast-DDS documentation](https://fast-dds.docs.eprosima.com/en/latest/).
@@ -67,7 +67,7 @@ CycloneDDS allows to specify DDS configuration through an XML file.
 In order to apply a configuration, the path to the XML file must be provided through the following environment variable:
 
 ```sh
-export CYCLONEDDS_URI=/path/to/the/xml/profile 
+export CYCLONEDDS_URI=/path/to/the/xml/profile
 ```
 
 Detailed network configurations are described in the [CycloneDDS documentation](https://github.com/eclipse-cyclonedds/cyclonedds#configuration).
@@ -127,3 +127,5 @@ The file must be edited replacing `${ROBOT_IP}` with the actual IP value, or exp
   </Domain>
 </CycloneDDS>
 ```
+
+[^1]: ROS 2 is governed by Open Robotics

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -54,6 +54,7 @@ nav:
       - Setup Compute Boards:
         - ROS 2 on an NVIDIA Jetson: setup/jetson.md
         - ROS 2 on a Pi 4: setup/pi4.md
+        - ROS 2 on Ubuntu 20.04: setup/ubuntu2004.md
         - NTP on Compute Board: setup/compute-ntp.md
     - APIs:
       - ROS 2 Interface: api/ros2.md


### PR DESCRIPTION
Removed a lot of information specific to Raspberry Pi and tested these directions with a VM on Windows. Short of OR improving their "not-Ubuntu" ROS 2 support, I think this will open doors for a lot of users.