### PR TITLE
Update xml-config.md

### DIFF
--- a/docs/setup/xml-config.md
+++ b/docs/setup/xml-config.md
@@ -23,8 +23,21 @@ Fast-DDS allows to specify DDS configuration through an XML file.
 In order to apply a configuration, the path to the XML file must be provided through the following environment variable:
 
 ```sh
-export FASTRTPS_DEFAULT_PROFILES_FILE=/path/to/the/xml/profile
+export FASTRTPS_DEFAULT_PROFILES_FILE='/path/to/the/xml/profile'
 ```
+Then run 
+
+```sh
+sudo nano ~/.bashrc
+```
+And check to make sure the above line of code is in the bottom of the file. If it isn't there, add it and save the document. 
+
+Then run 
+```sh
+source ~/.bashrc
+```
+
+Finally restart your machine. 
 
 Detailed network configurations are described in the [Fast-DDS documentation](https://fast-dds.docs.eprosima.com/en/latest/).
 


### PR DESCRIPTION
it would be helpful if the command: 

export FASTRTPS_DEFAULT_PROFILES_FILE=/path/to/the/xml/profile

was formatted like this 

export FASTRTPS_DEFAULT_PROFILES_FILE='/path/to/the/xml/profile' 

with an example that says maybe 

export FASTRTPS_DEFAULT_PROFILES_FILE='/home/username/disable_multicast.xml'

it would also be helpful if the page instructed you to check the bashrc file to make sure it got exported and add it there if it didn't. sudo nano ~/.bashrc

then to source ~/.bashrc 

then to restart the machine 

then you can run the topic list 

