### PR TITLE
Update board hookup organization.

### DIFF
--- a/docs/hw/hookup.md
+++ b/docs/hw/hookup.md
@@ -1,9 +1,11 @@
 # iRobot® Create® 3 Hardware Hookup Overview
-The Create® 3 is based on the Roomba®, a robot vacuum cleaner.
+The Create® 3 robot is based on the Roomba®, a robot vacuum cleaner.
 Its sensors, actuators, and compact design are capable of navigating and mapping a the whole floor of a home or office space.
-The robot also ships with an iRobot® Home Base™ Charging Station.
+The robot also ships with an iRobot® Home Base™ Charging Station. 
 
-## Currently documented hookup options:
+It is possible to directly connect various single board computers to the Create 3 robot in order to provide on-board intelligence. Here are a few examples.
+
+## Currently documented hookup examples:
 
 ### NavQ+ by NXP
 * [NavQ+ by NXP Hookup Guide](../navqplus_hookup/)

--- a/docs/hw/hookup.md
+++ b/docs/hw/hookup.md
@@ -1,87 +1,21 @@
-# iRobot® Create® 3 Hookup Guide
+# iRobot® Create® 3 Hardware Hookup Overview
+The Create® 3 is based on the Roomba®, a robot vacuum cleaner.
+Its sensors, actuators, and compact design are capable of navigating and mapping a the whole floor of a home or office space.
+The robot also ships with an iRobot® Home Base™ Charging Station.
 
-The iRobot® Create® 3 has a USB-C®[^1] connector implementing a USB 2.0 host capable of 5 V @ 3 A continuous, which can be used to power and communicate with various downstream devices.
-Here are some hookup examples.
+## Currently documented hookup options:
 
-## NXP NavQ+
-Since NavQ+ has USB-C® ports capable of being configured as a USB Ethernet Gadget, a cable with a USB-C® connector on both ends is all that is required.
+### NavQ+ by NXP
+* [NavQ+ by NXP Hookup Guide](../navqplus_hookup/)
 
-!!! note
-    - Unless set otherwise, the default USB-C® port for use as an Ethernet Gadget device is configured to only the centermost (USB 2) USB-C® as shown in the example pictures.
+### NVIDIA® Jetson™
+* [NVIDIA® Jetson™ Hookup Guide](../jetson_hookup/) [^1]
 
-The NavQ+ is pictured in the cargo bay using the 3D-printed adapter plate and on top of the faceplate using the 3D-printed case.
-![Hookup diagram for NavQ+ with adapter mount in cargo bay](data/hookup_navqplus_adapter_mount_bay.jpg "NavQ+ in Cargo Bay")
-![Hookup diagram for NavQ+ with case on faceplate](data/hookup_navqplus_case_faceplate.jpg "NavQ+ on Faceplate")
-
-The NavQ+ has a printable case specifically designed for use with the Create® 3, allowing for it to be mounted to the faceplate or cargo bay.
-The base of the case attaches to the NavQ+ using the existing four (4) M2.5-0.45 x 12mm System On Module (SOM) mounting screws.
-
-!!! note
-    - This case is designed to be fastened together with four (4) M3-0.5 x 10mm screws if not mounted to a Create® 3 plate or M3-0.5 x 12mm if mounted; cap head is suggested.
-    - For best results, it is suggested to tap/thread the M3-0.5 (Create® 3 mounting/case fastening) and M2.5-0.45 (SOM) holes.
-
-* [Case Top STL (170.5 kB)](data/cases/C3-NavQPlus-Top.stl)
-* [Case Top STEP (413.5 kB)](data/cases/C3-NavQPlus-Top.stp)
-
-* [Case Base STL (150.7 kB)](data/cases/C3-NavQPlus-Base.stp)
-* [Case Base STEP (130.2 kB)](data/cases/C3-NavQPlus-Base.stp)
-
-Setup showing faceplate mounted case and printable [sensor brackets](https://github.com/iRobotEducation/create3_docs/tree/main/docs/hw/data/brackets).
-![Sensor faceplate hookup example.](data/navqplus_case_sensors.jpg "NavQ+ with sensors on Faceplate")
+### Raspberry Pi® 
+* [Raspberry Pi® Hookup Guide](../rpi_hookup/) [^2]
 
 
-If a more minimal mount is desired instead of a case, an adapter plate using the existing SOM mounting screws for fastening is also provided.
 
-!!! note
-    - This adapter is designed to be fastened to the Create® 3 plate with four (4) M3-0.5 x 6mm screws; cap head is suggested.
-    - For best results, it is suggested to tap/thread the M3-0.5 (Create® 3 mounting) and M2.5-0.45 (SOM) holes.
-
-* [Adapter Plate STL (1.2 MB)](data/brackets/C3-RudisLabs-NavQPlus-Adapter.stl)
-* [Adapter Plate STEP (3.4 MB)](data/brackets/C3-RudisLabs-NavQPlus-Adapter.stp)
-
-
-## Raspberry Pi®
-The Raspberry Pi®[^2] mounting scheme does not match Create® 3's faceplate or cargo bay hole pattern; here are two 3D-printable mounts.
-The larger mount is more rigid but requires three times as much time to print.
-
-* [Small Mount (128kB)](data/brackets/C3-RPi-Mount-Small-20211022.stl)
-* [Large Mount (520kB)](data/brackets/C3-RPi-Mount-20211022.stl)
-
-### Raspberry Pi® 4
-Since the Raspberry Pi®[^2] 4 has a USB-C® port capable of an OTG connection, a cable with a USB-C® connector on both ends is all that is required.
-The Raspberry Pi® is pictured in the cargo bay with the large mount, and the Adapter Board is removed from the robot for clarity.
-![Hookup diagram for Raspberry Pi® 4](data/hookup_pi4.jpg "Raspberry Pi® 4")
-
-### Raspberry Pi® 1-3 Model B
-The original Raspberry Pi® through the Raspberry Pi® 3 do not have upstream (device) ports, so it's a little more difficult to connect and power them cleanly.
-We suggest using a USB-C® hub which includes an integrated USB to Ethernet adapter as the cleanest way to go.
-![Hookup diagram for Raspberry Pi® 3B](data/hookup_pi3b.jpg "Raspberry Pi® 3B")
-It's also possible to power the Raspberry Pi® using the USB-C® port on the Adapter Board with the help of a downstream connection adapter like [this one](https://www.adafruit.com/product/4090) and make the data connection over Wi-Fi.
-
-### Raspberry Pi® Zero
-This should be the same as the Raspberry Pi® 4.
-The Micro-USB connector labeled "USB" is an OTG port capable of being an Ethernet Gadget; use a USB Micro B to USB-C® cable to connect it directly to the robot's Adapter Board.
-![Hookup diagram for Raspberry Pi® Zero](data/hookup_piZ.jpg "Raspberry Pi® Zero")
-
-## NVIDIA® Jetson Nano™ 2GB
-The Jetson Nano™[^3] 2GB has a USB-C® port (J2) for power and a USB Micro-B port (J13) for downstream data.
-This can be connected to the Create 3 most simply using a USB-C® hub and two cables -- USB A to Micro-B and USB A to USB-C®.
-![Hookup diagram for Jetson Nano™](data/hookup_nano2gb.jpg "Jetson Nano™ 2GB")
-
-## NVIDIA® Jetson Xavier NX™ Developer Kit
-The [Jetson Xavier NX™ Developer Kit](https://developer.nvidia.com/embedded/jetson-xavier-nx-devkit) has a 5.5mm x 2.5mm barrel connector jack (J16) for power (9 V to 20 V) and a USB Micro-B port (J5) for downstream data.<br>
-This can be powered from the unregulated battery port of the Create® 3  adapter board by using a JST-XH female connector to DC barrel plug cable.
-The data connection is established by using a USB Micro B to USB-C® cable.
-![Hookup diagram for Jetson Xavier NX™ Developer Kit](data/hookup_jetson_xavier_nx.jpg "Jetson Xavier NX™ Developer Kit")
-
-### Mounting NVIDIA® Jetson Xavier NX™ Developer Kit
-You can 3d print the [mount adapter](data/brackets/C3-JetsonXavierNX-Mount.3mf) to place the Jetson Xavier NX Developer Kit in the cargo bay or on the faceplate.
-
-!!! note
-    - If you are 3d printing the above mount adapter, use **support** to support overhang areas. ([slicing example](data/brackets/C3-JetsonXavierNX-Mount_slice-example.png))
-    - You need four (4) M3 x 6mm screws; cap head is suggested.
-
-[^1]: USB-C® is a trademark of USB Implementers Forum.
+[^1]: NVIDIA and Jetson are trademarks or registered trademarks of NVIDIA Corporation.
 [^2]: Raspberry Pi® is a trademark of Raspberry Pi Trading.
-[^3]: NVIDIA and Jetson Nano are trademarks or registered trademarks of NVIDIA Corporation.
-[^4]: All other trademarks mentioned are the property of their respective owners.
+[^3]: All other trademarks mentioned are the property of their respective owners.

--- a/docs/hw/jetson_hookup.md
+++ b/docs/hw/jetson_hookup.md
@@ -1,0 +1,29 @@
+# iRobot® Create® 3 Hookup Guide for NVIDIA® Jetson™
+
+The iRobot® Create® 3 has a USB-C®[^1] connector implementing a USB 2.0 host capable of 5 V @ 3 A continuous, which can be used to power and communicate with various downstream devices.
+Here are some hookup examples for NVIDIA® Jetson™[^2] computers.
+
+## NVIDIA® Jetson Nano™ 2GB
+The Jetson Nano™ 2GB has a USB-C® port (J2) for power and a USB Micro-B port (J13) for downstream data.
+This can be connected to the Create 3 most simply using a USB-C® hub and two cables -- USB A to Micro-B and USB A to USB-C®.
+![Hookup diagram for Jetson Nano™](data/hookup_nano2gb.jpg "Jetson Nano™ 2GB")
+
+## NVIDIA® Jetson Xavier NX™ Developer Kit
+The [Jetson Xavier NX™ Developer Kit](https://developer.nvidia.com/embedded/jetson-xavier-nx-devkit) has a 5.5mm x 2.5mm barrel connector jack (J16) for power (9 V to 20 V) and a USB Micro-B port (J5) for downstream data.<br>
+This can be powered from the unregulated battery port of the Create® 3  adapter board by using a JST-XH female connector to DC barrel plug cable.
+The data connection is established by using a USB Micro B to USB-C® cable.
+![Hookup diagram for Jetson Xavier NX™ Developer Kit](data/hookup_jetson_xavier_nx.jpg "Jetson Xavier NX™ Developer Kit")
+
+### NVIDIA® Jetson Xavier NX™ Developer Kit Printable Adapter Mount
+You can 3d print the mount adapter to place the Jetson Xavier NX Developer Kit in the cargo bay or on the faceplate.
+
+* [Adapter Mount STL (338.4 kB)](data/brackets/C3-JetsonXavierNX-Mount.stl)
+* [Adapter Mount 3MF (95.9 kB)](data/brackets/C3-JetsonXavierNX-Mount.3mf)
+
+!!! note
+    - If you are 3d printing the above mount adapter, use **support** to support overhang areas. ([slicing example](data/brackets/C3-JetsonXavierNX-Mount_slice-example.png))
+    - You need four (4) M3 x 6mm screws; cap head is suggested.
+
+[^1]: USB-C® is a trademark of USB Implementers Forum.
+[^2]: NVIDIA and Jetson are trademarks or registered trademarks of NVIDIA Corporation.
+[^3]: All other trademarks mentioned are the property of their respective owners.

--- a/docs/hw/jetson_hookup.md
+++ b/docs/hw/jetson_hookup.md
@@ -1,11 +1,11 @@
 # iRobot® Create® 3 Hookup Guide for NVIDIA® Jetson™
 
-The iRobot® Create® 3 has a USB-C®[^1] connector implementing a USB 2.0 host capable of 5 V @ 3 A continuous, which can be used to power and communicate with various downstream devices.
+The iRobot® Create® 3 robot has a USB-C®[^1] connector implementing a USB 2.0 host capable of 5 V @ 3 A continuous, which can be used to power and communicate with various downstream devices.
 Here are some hookup examples for NVIDIA® Jetson™[^2] computers.
 
 ## NVIDIA® Jetson Nano™ 2GB
 The Jetson Nano™ 2GB has a USB-C® port (J2) for power and a USB Micro-B port (J13) for downstream data.
-This can be connected to the Create 3 most simply using a USB-C® hub and two cables -- USB A to Micro-B and USB A to USB-C®.
+This can be connected to the Create 3 robot most simply using a USB-C® hub and two cables -- USB A to Micro-B and USB A to USB-C®.
 ![Hookup diagram for Jetson Nano™](data/hookup_nano2gb.jpg "Jetson Nano™ 2GB")
 
 ## NVIDIA® Jetson Xavier NX™ Developer Kit

--- a/docs/hw/navqplus_hookup.md
+++ b/docs/hw/navqplus_hookup.md
@@ -1,12 +1,12 @@
 # iRobot® Create® 3 Hookup Guide for NavQ+ by NXP
 
-The iRobot® Create® 3 has a USB-C®[^1] connector implementing a USB 2.0 host capable of 5 V @ 3 A continuous, which can be used to power and communicate with various downstream devices.
+The iRobot® Create® 3 robot has a USB-C®[^1] connector implementing a USB 2.0 host capable of 5 V @ 3 A continuous, which can be used to power and communicate with various downstream devices.
 
 NavQ+ is an open source reference design provided by NXP and manufacturable by anyone.
 Since NavQ+ has USB-C® ports capable of being configured as a USB Ethernet Gadget, a cable with a USB-C® connector on both ends is all that is required.
 
 !!! note
-    - Unless set otherwise, the default USB-C® port for use as an Ethernet Gadget device is configured to only the centermost (USB 2) USB-C® as shown in the example pictures.
+    - Unless set otherwise, the default USB-C® port for use as an Ethernet Gadget device is configured to only the centermost USB-C® port (labeled USB 2) as shown in the example pictures.
 
 The NavQ+ is pictured in the cargo bay using the 3D-printed [adapter](#adapter) plate and on top of the faceplate using the 3D-printed [case](#case-top).
 ![Hookup diagram for NavQ+ with adapter mount in cargo bay](data/hookup_navqplus_adapter_mount_bay.jpg "NavQ+ in Cargo Bay")

--- a/docs/hw/navqplus_hookup.md
+++ b/docs/hw/navqplus_hookup.md
@@ -1,0 +1,48 @@
+# iRobot® Create® 3 Hookup Guide for NavQ+ by NXP
+
+The iRobot® Create® 3 has a USB-C®[^1] connector implementing a USB 2.0 host capable of 5 V @ 3 A continuous, which can be used to power and communicate with various downstream devices.
+
+NavQ+ is an open source reference design provided by NXP and manufacturable by anyone.
+Since NavQ+ has USB-C® ports capable of being configured as a USB Ethernet Gadget, a cable with a USB-C® connector on both ends is all that is required.
+
+!!! note
+    - Unless set otherwise, the default USB-C® port for use as an Ethernet Gadget device is configured to only the centermost (USB 2) USB-C® as shown in the example pictures.
+
+The NavQ+ is pictured in the cargo bay using the 3D-printed [adapter](#adapter) plate and on top of the faceplate using the 3D-printed [case](#case-top).
+![Hookup diagram for NavQ+ with adapter mount in cargo bay](data/hookup_navqplus_adapter_mount_bay.jpg "NavQ+ in Cargo Bay")
+![Hookup diagram for NavQ+ with case on faceplate](data/hookup_navqplus_case_faceplate.jpg "NavQ+ on Faceplate")
+
+
+## Printable Case
+The NavQ+ has a printable case specifically designed for use with the Create® 3, allowing for it to be mounted to the faceplate or cargo bay.
+The base of the case attaches to the NavQ+ using the existing four (4) M2.5-0.45 x 12mm System On Module (SOM) mounting screws.
+
+!!! note
+    - This case is designed to be fastened together with four (4) M3-0.5 x 10mm screws if not mounted to a Create® 3 plate or M3-0.5 x 12mm if mounted; cap head is suggested.
+    - For best results, it is suggested to tap/thread the M3-0.5 (Create® 3 mounting/case fastening) and M2.5-0.45 (SOM) holes.
+
+### Case Top
+* [Case Top STL (170.5 kB)](data/cases/C3-NavQPlus-Top.stl)
+* [Case Top STEP (413.5 kB)](data/cases/C3-NavQPlus-Top.stp)
+
+### Case Bottom
+* [Case Base STL (150.7 kB)](data/cases/C3-NavQPlus-Base.stl)
+* [Case Base STEP (130.2 kB)](data/cases/C3-NavQPlus-Base.stp)
+
+Setup showing faceplate mounted case and printable [sensor brackets](https://github.com/iRobotEducation/create3_docs/tree/main/docs/hw/data/brackets).
+![Sensor faceplate hookup example.](data/navqplus_case_sensors.jpg "NavQ+ with sensors on Faceplate")
+
+
+## Printable Adapter
+If a more minimal mount is desired instead of a case, an adapter plate using the existing SOM mounting screws for fastening is also provided.
+
+!!! note
+    - This adapter is designed to be fastened to the Create® 3 plate with four (4) M3-0.5 x 6mm screws; cap head is suggested.
+    - For best results, it is suggested to tap/thread the M3-0.5 (Create® 3 mounting) and M2.5-0.45 (SOM) holes.
+
+### Adapter
+* [Adapter STL (1.2 MB)](data/brackets/C3-RudisLabs-NavQPlus-Adapter.stl)
+* [Adapter STEP (3.4 MB)](data/brackets/C3-RudisLabs-NavQPlus-Adapter.stp)
+
+[^1]: USB-C® is a trademark of USB Implementers Forum.
+[^2]: All other trademarks mentioned are the property of their respective owners.

--- a/docs/hw/rpi_hookup.md
+++ b/docs/hw/rpi_hookup.md
@@ -1,6 +1,6 @@
 # iRobot® Create® 3 Hookup Guide for Raspberry Pi®
 
-The iRobot® Create® 3 has a USB-C®[^1] connector implementing a USB 2.0 host capable of 5 V @ 3 A continuous, which can be used to power and communicate with various downstream devices.
+The iRobot® Create® 3 robot has a USB-C®[^1] connector implementing a USB 2.0 host capable of 5 V @ 3 A continuous, which can be used to power and communicate with various downstream devices.
 Here are some hookup examples for Raspberry Pi®[^2] computers.
 
 ## Raspberry Pi® 4

--- a/docs/hw/rpi_hookup.md
+++ b/docs/hw/rpi_hookup.md
@@ -1,0 +1,35 @@
+# iRobot® Create® 3 Hookup Guide for Raspberry Pi®
+
+The iRobot® Create® 3 has a USB-C®[^1] connector implementing a USB 2.0 host capable of 5 V @ 3 A continuous, which can be used to power and communicate with various downstream devices.
+Here are some hookup examples for Raspberry Pi®[^2] computers.
+
+## Raspberry Pi® 4
+Since the Raspberry Pi® 4 has a USB-C® port capable of an OTG connection, a cable with a USB-C® connector on both ends is all that is required.
+The Raspberry Pi® is pictured in the cargo bay with the [large mount](#large-mount), and the Adapter Board is removed from the robot for clarity.
+![Hookup diagram for Raspberry Pi® 4](data/hookup_pi4.jpg "Raspberry Pi® 4")
+
+## Raspberry Pi® 1-3 Model B
+The original Raspberry Pi® through the Raspberry Pi® 3 do not have upstream (device) ports, so it's a little more difficult to connect and power them cleanly.
+We suggest using a USB-C® hub which includes an integrated USB to Ethernet adapter as the cleanest way to go.
+![Hookup diagram for Raspberry Pi® 3B](data/hookup_pi3b.jpg "Raspberry Pi® 3B")
+It's also possible to power the Raspberry Pi® using the USB-C® port on the Adapter Board with the help of a downstream connection adapter like [this one](https://www.adafruit.com/product/4090) and make the data connection over Wi-Fi.
+
+## Raspberry Pi® Zero
+This should be the same as the Raspberry Pi® 4.
+The Micro-USB connector labeled "USB" is an OTG port capable of being an Ethernet Gadget; use a USB Micro B to USB-C® cable to connect it directly to the robot's Adapter Board.
+![Hookup diagram for Raspberry Pi® Zero](data/hookup_piZ.jpg "Raspberry Pi® Zero")
+
+## Raspberry Pi® Printable Mounts
+The Raspberry Pi® mounting scheme does not match Create® 3's faceplate or cargo bay hole pattern; here are two 3D-printable mounts.
+The larger mount is more rigid but requires three times as much time to print.
+
+### Small Mount
+* [Small Mount STL (130.1 kB)](data/brackets/C3-RPi-Mount-Small-20211022.stl)
+
+
+### Large Mount
+* [Large Mount STL (532.9 kB)](data/brackets/C3-RPi-Mount-20211022.stl)
+
+[^1]: USB-C® is a trademark of USB Implementers Forum.
+[^2]: Raspberry Pi® is a trademark of Raspberry Pi Trading.
+[^3]: All other trademarks mentioned are the property of their respective owners.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -57,21 +57,21 @@ nav:
     - Setup:
       - Connect to Wi-Fi: setup/provision.md
       - Multi-Robot Setup: setup/multi-robot.md
-      - ROS 2 Network Config: setup/xml-config.md
-      - Connected Computers:
-        - ROS 2 on Ubuntu 20.04: setup/ubuntu2004.md
-        - Desktop Docker: setup/docker.md
-      - Compute Boards: 
+      - ROS 2 Setup:
+        - Install on Ubuntu: setup/ubuntu2004.md
+        - Run with Docker: setup/docker.md
+        - Network Config: setup/xml-config.md
+      - Add a Compute Board: 
         - NavQ+ by NXP:
-          - Mechanical and Electrical Hookup: hw/navqplus_hookup.md
-          - Configure ROS 2: setup/navqplus.md
+          - Hookup Guide: hw/navqplus_hookup.md
+          - Software Config: setup/navqplus.md
         - NVIDIA® Jetson™:
-          - Mechanical and Electrical Hookup: hw/jetson_hookup.md
-          - Configure ROS 2: setup/jetson.md
+          - Hookup Guide: hw/jetson_hookup.md
+          - Software Config: setup/jetson.md
         - Raspberry Pi®:
-          - Mechanical and Electrical Hookup: hw/rpi_hookup.md
-          - Configure ROS 2: setup/pi4.md
-        - NTP on Compute Board: setup/compute-ntp.md
+          - Hookup Guide: hw/rpi_hookup.md
+          - Software Config: setup/pi4.md
+        - Network Time Protocol: setup/compute-ntp.md
     - APIs:
       - ROS 2 Interface: api/ros2.md
       - Docking: api/docking.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -46,7 +46,6 @@ nav:
         - Electrical Overview: hw/electrical.md
         - Buttons and Light Ring: hw/face.md
         - Adapter Board: hw/adapter.md
-      - Hookup Examples: hw/hookup.md
     - Webserver:
       - Overview: webserver/overview.md
       - Home: webserver/home.md
@@ -59,13 +58,20 @@ nav:
       - Connect to Wi-Fi: setup/provision.md
       - Multi-Robot Setup: setup/multi-robot.md
       - ROS 2 Network Config: setup/xml-config.md
-      - Setup Compute Boards:
+      - Connected Computers:
         - ROS 2 on Ubuntu 20.04: setup/ubuntu2004.md
-        - ROS 2 on a NavQ+: setup/navqplus.md
-        - ROS 2 on a Pi 4: setup/pi4.md
-        - ROS 2 on an NVIDIA Jetson: setup/jetson.md
-        - NTP on Compute Board: setup/compute-ntp.md
         - Desktop Docker: setup/docker.md
+      - Compute Boards: 
+        - NavQ+ by NXP:
+          - Mechanical and Electrical Hookup: hw/navqplus_hookup.md
+          - Configure ROS 2: setup/navqplus.md
+        - NVIDIA® Jetson™:
+          - Mechanical and Electrical Hookup: hw/jetson_hookup.md
+          - Configure ROS 2: setup/jetson.md
+        - Raspberry Pi®:
+          - Mechanical and Electrical Hookup: hw/rpi_hookup.md
+          - Configure ROS 2: setup/pi4.md
+        - NTP on Compute Board: setup/compute-ntp.md
     - APIs:
       - ROS 2 Interface: api/ros2.md
       - Docking: api/docking.md


### PR DESCRIPTION
This is split out from a previous closed [PR 167](https://github.com/iRobotEducation/create3_docs/pull/167) and creates a cleaner layout for the connected compute boards. 