### PR TITLE
3D visuals and mounting resource page.

### DIFF
--- a/docs/hw/jetson_hookup.md
+++ b/docs/hw/jetson_hookup.md
@@ -17,6 +17,14 @@ The data connection is established by using a USB Micro B to USB-C® cable.
 ### NVIDIA® Jetson Xavier NX™ Developer Kit Printable Adapter Mount
 You can 3d print the mount adapter to place the Jetson Xavier NX Developer Kit in the cargo bay or on the faceplate.
 
+<details>
+  <summary>3D-Rendering</summary>
+
+  <script src="https://embed.github.com/view/3d/iRobotEducation/create3_docs/main/docs/hw/data/brackets/data/brackets/C3-JetsonXavierNX-Mount.stl"></script>
+
+</details>
+
+
 * [Adapter Mount STL (338.4 kB)](data/brackets/C3-JetsonXavierNX-Mount.stl)
 * [Adapter Mount 3MF (95.9 kB)](data/brackets/C3-JetsonXavierNX-Mount.3mf)
 

--- a/docs/hw/mounts_cases_adapters.md
+++ b/docs/hw/mounts_cases_adapters.md
@@ -1,0 +1,245 @@
+# iRobot® Create® 3 Mounts, Cases, and Adapters
+
+## General
+### Caster
+#### Cargo Bay with Caster
+<details>
+  <summary>3D-Rendering</summary>
+
+  <script src="https://embed.github.com/view/3d/iRobotEducation/create3_docs/main/docs/hw/data/brackets/C3-Cargo-Bay-With-Caster.stl"></script>
+
+</details>
+
+
+
+* [STL (10.4 MB)](data/brackets/C3-Cargo-Bay-With-Caster.stl)
+
+#### Caster Lock
+<details>
+  <summary>3D-Rendering</summary>
+
+  <script src="https://embed.github.com/view/3d/iRobotEducation/create3_docs/main/docs/hw/data/brackets/C3-Caster-Lock.stl"></script>
+
+</details>
+
+
+
+* [STL (53.7 kB)](data/brackets/C3-Caster-Lock.stl)
+
+#### Rear Caster Attachment
+<details>
+  <summary>3D-Rendering</summary>
+
+  <script src="https://embed.github.com/view/3d/iRobotEducation/create3_docs/main/docs/hw/data/brackets/C3-Rear-Caster-Attachment.stl"></script>
+
+</details>
+
+
+
+* [STL (828.0 kB)](data/brackets/C3-Rear-Caster-Attachment.stl)
+
+#### Rear Caster Attachment Latch
+<details>
+  <summary>3D-Rendering</summary>
+
+  <script src="https://embed.github.com/view/3d/iRobotEducation/create3_docs/main/docs/hw/data/brackets/C3-Rear-Caster-Attachment-Latch.stl"></script>
+
+</details>
+
+
+
+* [STL (52.5 kB)](data/brackets/C3-Rear-Caster-Attachment-Latch.stl)
+
+
+### Stud Mount
+<details>
+  <summary>3D-Rendering</summary>
+
+  <script src="https://embed.github.com/view/3d/iRobotEducation/create3_docs/main/docs/hw/data/brackets/C3-Stud-Mount.stl"></script>
+
+</details>
+
+
+
+* [STL (590.5 kB)](data/brackets/C3-Stud-Mount.stl)
+
+### Universal 1/4-20 UNC Post Mount
+Mount can be used with any 1/4-20 threaded camera or sensor.
+<details>
+  <summary>3D-Rendering</summary>
+
+  <script src="https://embed.github.com/view/3d/iRobotEducation/create3_docs/main/docs/hw/data/brackets/C3-RudisLabs-Threaded-1_4-20UNC-post-mount.stl"></script>
+
+</details>
+
+
+
+* [STL (410.6 kB)](data/brackets/C3-RudisLabs-Threaded-1_4-20UNC-post-mount.stl)
+* [STEP (688.2 kB)](data/brackets/C3-RudisLabs-Threaded-1_4-20UNC-post-mount.stp)
+
+## Sensors
+### Oak-D
+All Oak-D sensors can also be mounted with the [Universal 1/4-20 UNC Post Mount](#universal-14-20-unc-post-mount).
+
+#### Oak-D Mount
+<details>
+  <summary>3D-Rendering</summary>
+
+  <script src="https://embed.github.com/view/3d/iRobotEducation/create3_docs/main/docs/hw/data/brackets/C3-OAK-D-Mount.stl"></script>
+
+</details>
+
+
+
+* [STL (401.9 kB)](data/brackets/C3-OAK-D-Mount.stl)
+
+#### Oak-D Lite Mount
+<details>
+  <summary>3D-Rendering</summary>
+
+  <script src="https://embed.github.com/view/3d/iRobotEducation/create3_docs/main/docs/hw/data/brackets/C3-OAK-D-Lite-Mount.stl"></script>
+
+</details>
+
+
+
+* [STL (422.9 kB)](data/brackets/C3-OAK-D-Lite-Mount.stl)
+
+### Realsense
+All Realsense sensors can also be mounted with the [Universal 1/4-20 UNC Post Mount](#universal-14-20-unc-post-mount).
+
+#### D435 Mount
+<details>
+  <summary>3D-Rendering</summary>
+
+  <script src="https://embed.github.com/view/3d/iRobotEducation/create3_docs/main/docs/hw/data/brackets/C3-RealSense-D435-Mount.stl"></script>
+
+</details>
+
+
+
+* [STL (462.3 kB)](data/brackets/C3-RealSense-D435-Mount.stl)
+
+### RPLidar
+#### A1M8 Minimal Mount
+<details>
+  <summary>3D-Rendering</summary>
+
+  <script src="https://embed.github.com/view/3d/iRobotEducation/create3_docs/main/docs/hw/data/brackets/C3-RudisLabs-Minimal-RPLIDAR-A1M8-Adapter.stl"></script>
+
+</details>
+
+
+
+* [STL (396.5 kB)](data/brackets/C3-RudisLabs-Minimal-RPLIDAR-A1M8-Adapter.stl)
+* [STEP (1.4 MB)](data/brackets/C3-RudisLabs-Minimal-RPLIDAR-A1M8-Adapter.stp)
+
+#### A1 Large Mount
+<details>
+  <summary>3D-Rendering</summary>
+
+  <script src="https://embed.github.com/view/3d/iRobotEducation/create3_docs/main/docs/hw/data/brackets/C3-RPLidar-A1-Mount.stl"></script>
+
+</details>
+
+
+
+* [STL (1.1 MB)](data/brackets/C3-RPLidar-A1-Mount.stl)
+
+#### A1 USB Mount
+<details>
+  <summary>3D-Rendering</summary>
+
+  <script src="https://embed.github.com/view/3d/iRobotEducation/create3_docs/main/docs/hw/data/brackets/C3-RPLidar-A1-USB-Mount.stl"></script>
+
+</details>
+
+
+
+* [STL (465.4 kB)](data/brackets/C3-RPLidar-A1-USB-Mount.stl)
+
+
+## Compute Boards
+### NavQ+ by NXP
+#### Adapter
+<details>
+  <summary>3D-Rendering</summary>
+
+  <script src="https://embed.github.com/view/3d/iRobotEducation/create3_docs/main/docs/hw/data/brackets/C3-RudisLabs-NavQPlus-Adapter.stl"></script>
+
+</details>
+
+
+
+* [STL (1.2 MB)](data/brackets/C3-RudisLabs-NavQPlus-Adapter.stl)
+* [STEP (3.4 MB)](data/brackets/C3-RudisLabs-NavQPlus-Adapter.stp)
+
+#### Case Top
+<details>
+  <summary>3D-Rendering</summary>
+
+  <script src="https://embed.github.com/view/3d/iRobotEducation/create3_docs/main/docs/hw/data/cases/C3-NavQPlus-Top.stl"></script>
+
+</details>
+
+
+
+* [STL (170.5 kB)](data/cases/C3-NavQPlus-Top.stl)
+* [STEP (413.5 kB)](data/cases/C3-NavQPlus-Top.stp)
+
+#### Case Bottom
+<details>
+  <summary>3D-Rendering</summary>
+
+  <script src="https://embed.github.com/view/3d/iRobotEducation/create3_docs/main/docs/hw/data/cases/C3-NavQPlus-Base.stl"></script>
+
+</details>
+
+
+
+* [STL (150.7 kB)](data/cases/C3-NavQPlus-Base.stl)
+* [STEP (130.2 kB)](data/cases/C3-NavQPlus-Base.stp)
+
+
+### NVIDIA® Jetson Xavier NX™ Developer Kit Mount
+#### Adapter Mount
+<details>
+  <summary>3D-Rendering</summary>
+
+  <script src="https://embed.github.com/view/3d/iRobotEducation/create3_docs/main/docs/hw/data/brackets/data/brackets/C3-JetsonXavierNX-Mount.stl"></script>
+
+</details>
+
+
+
+* [STL (338.4 kB)](data/brackets/C3-JetsonXavierNX-Mount.stl)
+* [3MF (95.9 kB)](data/brackets/C3-JetsonXavierNX-Mount.3mf)
+
+
+### Raspberry Pi®
+#### Small Mount
+<details>
+  <summary>3D-Rendering</summary>
+
+  <script src="https://embed.github.com/view/3d/iRobotEducation/create3_docs/main/docs/hw/data/brackets/C3-RPi-Mount-Small-20211022.stl"></script>
+
+</details>
+
+
+
+* [STL (128kB)](data/brackets/C3-RPi-Mount-Small-20211022.stl)
+
+
+#### Large Mount
+<details>
+  <summary>3D-Rendering</summary>
+
+  <script src="https://embed.github.com/view/3d/iRobotEducation/create3_docs/main/docs/hw/data/brackets/C3-RPi-Mount-20211022.stl"></script>
+
+</details>
+
+
+
+* [STL (520kB)](data/brackets/C3-RPi-Mount-20211022.stl)
+
+[^1]: All trademarks mentioned are the property of their respective owners.

--- a/docs/hw/navqplus_hookup.md
+++ b/docs/hw/navqplus_hookup.md
@@ -22,10 +22,26 @@ The base of the case attaches to the NavQ+ using the existing four (4) M2.5-0.45
     - For best results, it is suggested to tap/thread the M3-0.5 (Create® 3 mounting/case fastening) and M2.5-0.45 (SOM) holes.
 
 ### Case Top
+<details>
+  <summary>3D-Rendering</summary>
+
+  <script src="https://embed.github.com/view/3d/iRobotEducation/create3_docs/main/docs/hw/data/cases/C3-NavQPlus-Top.stl"></script>
+
+</details>
+
+
 * [Case Top STL (170.5 kB)](data/cases/C3-NavQPlus-Top.stl)
 * [Case Top STEP (413.5 kB)](data/cases/C3-NavQPlus-Top.stp)
 
 ### Case Bottom
+<details>
+  <summary>3D-Rendering</summary>
+
+  <script src="https://embed.github.com/view/3d/iRobotEducation/create3_docs/main/docs/hw/data/cases/C3-NavQPlus-Base.stl"></script>
+
+</details>
+
+
 * [Case Base STL (150.7 kB)](data/cases/C3-NavQPlus-Base.stl)
 * [Case Base STEP (130.2 kB)](data/cases/C3-NavQPlus-Base.stp)
 
@@ -41,6 +57,15 @@ If a more minimal mount is desired instead of a case, an adapter plate using the
     - For best results, it is suggested to tap/thread the M3-0.5 (Create® 3 mounting) and M2.5-0.45 (SOM) holes.
 
 ### Adapter
+
+<details>
+  <summary>3D-Rendering</summary>
+
+  <script src="https://embed.github.com/view/3d/iRobotEducation/create3_docs/main/docs/hw/data/brackets/C3-RudisLabs-NavQPlus-Adapter.stl"></script>
+
+</details>
+
+
 * [Adapter STL (1.2 MB)](data/brackets/C3-RudisLabs-NavQPlus-Adapter.stl)
 * [Adapter STEP (3.4 MB)](data/brackets/C3-RudisLabs-NavQPlus-Adapter.stp)
 

--- a/docs/hw/rpi_hookup.md
+++ b/docs/hw/rpi_hookup.md
@@ -24,10 +24,28 @@ The Raspberry Pi® mounting scheme does not match Create® 3's faceplate or carg
 The larger mount is more rigid but requires three times as much time to print.
 
 ### Small Mount
+
+<details>
+  <summary>3D-Rendering</summary>
+
+  <script src="https://embed.github.com/view/3d/iRobotEducation/create3_docs/main/docs/hw/data/brackets/C3-RPi-Mount-Small-20211022.stl"></script>
+
+</details>
+
+
 * [Small Mount STL (130.1 kB)](data/brackets/C3-RPi-Mount-Small-20211022.stl)
 
 
 ### Large Mount
+
+<details>
+  <summary>3D-Rendering</summary>
+
+  <script src="https://embed.github.com/view/3d/iRobotEducation/create3_docs/main/docs/hw/data/brackets/C3-RPi-Mount-20211022.stl"></script>
+
+</details>
+
+
 * [Large Mount STL (532.9 kB)](data/brackets/C3-RPi-Mount-20211022.stl)
 
 [^1]: USB-C® is a trademark of USB Implementers Forum.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -46,6 +46,7 @@ nav:
         - Electrical Overview: hw/electrical.md
         - Buttons and Light Ring: hw/face.md
         - Adapter Board: hw/adapter.md
+      - Mounts, Cases, Adapters: hw/mounts_cases_adapters.md
     - Webserver:
       - Overview: webserver/overview.md
       - Home: webserver/home.md


### PR DESCRIPTION
Provides optional (expandable and rotatable) rendering of files provided by github's existing back-end.

Also includes listing of all files in a dedicated page.

Might want to possible rework hw/mechanical page for cohesive reference if this style is desired.

@shamlian @Rebecca-iRobot this is the cleaned up version of what you had seen.