### PR TITLE
Fixing reflex parameters (should be "reflexes.*")

### DIFF
--- a/docs/api/reflexes.md
+++ b/docs/api/reflexes.md
@@ -15,7 +15,7 @@ This parameter is set to true by default, so reflexes are generally enabled, but
 
 ### Bumps reflex
 
-The `reflex.REFLEX_BUMP` ROS 2 parameter enables (`true`) or disables (`false`) the bump reflex.
+The `reflexes.REFLEX_BUMP` ROS 2 parameter enables (`true`) or disables (`false`) the bump reflex.
 It will trigger as soon as the robot bumps into an obstacle and it will move the robot away from it.
 The reflex will continue until the robot has cleared the bump.
 
@@ -23,7 +23,7 @@ This reflex is enabled by default.
 
 ### Cliffs reflex
 
-The `reflex.REFLEX_CLIFF` ROS 2 parameter enables (`true`) or disables (`false`) the cliff reflex.
+The `reflexes.REFLEX_CLIFF` ROS 2 parameter enables (`true`) or disables (`false`) the cliff reflex.
 It will trigger as soon as the robot detects a cliff and it will move the robot away from it.
 The reflex will continue until the robot has cleared the cliff.
 
@@ -31,7 +31,7 @@ This reflex is enabled by default.
 
 ### Dock avoidance reflex
 
-The `reflex.REFLEX_DOCK_AVOID` ROS 2 parameter enables (`true`) or disables (`false`) the dock avoidance reflex.
+The `reflexes.REFLEX_DOCK_AVOID` ROS 2 parameter enables (`true`) or disables (`false`) the dock avoidance reflex.
 It will trigger as soon as the robot gets close to the dock and tries to move towards it.
 The reflex will stop forward movements.
 
@@ -39,14 +39,14 @@ This reflex is disabled by default.
 
 ### Gyro calibration reflex
 
-The `reflex.REFLEX_GYRO_CAL` ROS 2 parameter enables (`true`) or disables (`false`) the gyro calibration reflex.
+The `reflexes.REFLEX_GYRO_CAL` ROS 2 parameter enables (`true`) or disables (`false`) the gyro calibration reflex.
 It will trigger while the robot is stationary and will try to recalibrate the internal gyroscope.
 
 This reflex is enabled by default.
 
 ### Panic reflex
 
-The `reflex.REFLEX_PANIC` ROS 2 parameter enables (`true`) or disables (`false`) the panic reflex.
+The `reflexes.REFLEX_PANIC` ROS 2 parameter enables (`true`) or disables (`false`) the panic reflex.
 It will trigger when the robot is trapped and unable to clear obstacles or hazards.
 The reflex will try more aggressive maneuvers to allow the robot to recover from this situation
 
@@ -54,7 +54,7 @@ This reflex is enabled by default.
 
 ### Proximity slowdown reflex
 
-The `reflex.REFLEX_PROXIMITY_SLOWDOWN` ROS 2 parameter enables (`true`) or disables (`false`) the proximity slowdown reflex.
+The `reflexes.REFLEX_PROXIMITY_SLOWDOWN` ROS 2 parameter enables (`true`) or disables (`false`) the proximity slowdown reflex.
 It will trigger when the robot's IR sensors detect an obstacle in close proximity.
 The reflex will reduce the robot movement speed in order to better prepare for an eventual impact.
 
@@ -62,7 +62,7 @@ This reflex is enabled by default.
 
 ### Stuck reflex
 
-The `reflex.REFLEX_STUCK` ROS 2 parameter enables (`true`) or disables (`false`) the stuck reflex.
+The `reflexes.REFLEX_STUCK` ROS 2 parameter enables (`true`) or disables (`false`) the stuck reflex.
 It will trigger when the robot is stuck, i.e. it's pushing against an obstacle and its wheels are losing traction.
 The reflex will try aggressive maneuvers to allow the robot to recover from this situation
 
@@ -70,7 +70,7 @@ This reflex is enabled by default.
 
 ### Virtual Wall reflex
 
-The `reflex.REFLEX_VIRTUAL_WALL` ROS 2 parameter enables (`true`) or disables (`false`) the virtual wall reflex.
+The `reflexes.REFLEX_VIRTUAL_WALL` ROS 2 parameter enables (`true`) or disables (`false`) the virtual wall reflex.
 It will trigger as soon as the robot detects an iRobot virtual wall it will move the robot away from it.
 The reflex will continue until the robot has cleared the virtual wall.
 
@@ -78,7 +78,7 @@ This reflex is enabled by default.
 
 ### Wheel drop reflex
 
-The `reflex.REFLEX_WHEEL_DROP` ROS 2 parameter enables (`true`) or disables (`false`) the wheel drop reflex.
+The `reflexes.REFLEX_WHEEL_DROP` ROS 2 parameter enables (`true`) or disables (`false`) the wheel drop reflex.
 It will trigger as soon as the robot detects that one of its wheels is fully extended (dropped).
 The robot will drive the other wheel in order to return to a flat surface.
 


### PR DESCRIPTION
In testing reflexes again, I found (and Erik confirmed) that there is a docs typo.