### PR TITLE
Adding docking differences between Galactic and Humble to docs

### DIFF
--- a/docs/api/docking.md
+++ b/docs/api/docking.md
@@ -4,7 +4,10 @@ The Create® 3 robot is equipped with a docking station to recharge it between e
 
 Through the ROS 2 APIs users can command docking and undocking autonomous behaviors.
 
-Note that, in order for the robot to detect the dock, determine its location and understand when it is succesfully docked, it is necessary that the docking station is connected to a power source.
+!!! warning
+    Note that the docking action and sensor topic changed between Galactic and Humble.
+
+In order for the robot to detect the dock, determine its location, and understand when it is succesfully docked, it is necessary that the docking station is connected to a power source.
 
 ## Built-in docking behaviors
 
@@ -22,15 +25,21 @@ This action will fail if the robot is already undocked.
 
 #### Docking
 
-You can command the robot to dock using the following ROS 2 action.
+You can command the robot to dock using a ROS 2 action.
 
+##### Galactic
 ```bash
 ros2 action send_goal /dock irobot_create_msgs/action/DockServo "{}"
 ```
 
+##### Humble
+```bash
+ros2 action send_goal /dock irobot_create_msgs/action/Dock "{}"
+```
+
 The robot will first search for the dock in its immediate surroundings.
 Note that the action will fail if the robot is too far from the dock.
-You can check if the dock is visible by subscribing to the `/dock` ROS 2 topic.
+You can check if the dock is visible by subscribing to the (in Galactic) `/dock` (or in Humble) `/dock_status` ROS 2 topic.
 
 Then the robot will align with the dock and carefully drive onto it.
 
@@ -53,5 +62,6 @@ Each message will contain a time-stamped detection of one of those signals, incl
 
 #### Dock information
 
-More high-level information is produced by the robot in the `/dock` ROS 2 topic.
+In Galactic, more high-level information is produced by the robot in the `/dock` ROS 2 topic.
+In Humble and beyond, the topic has been renamed to `/dock_status`.
 Here it's possible to quickly know if the robot is able to see the dock from its current location and whether it is currently docked or not.

--- a/docs/examples/actuators-cli.md
+++ b/docs/examples/actuators-cli.md
@@ -77,8 +77,14 @@ ros2 action send_goal /undock irobot_create_msgs/action/Undock "{}"
 
 If the Create® 3 robot sees its dock (check the [docking documentation](../../api/docking) for details) you can dock it with:
 
+##### Galactic
 ```sh
 ros2 action send_goal /dock irobot_create_msgs/action/DockServo "{}"
+```
+
+##### Humble
+```sh
+ros2 action send_goal /dock irobot_create_msgs/action/Dock "{}"
 ```
 
 ### E-Stop

--- a/docs/examples/sensors-cli.md
+++ b/docs/examples/sensors-cli.md
@@ -29,9 +29,16 @@ ros2 topic echo /interface_buttons
 ```
 
 ### Docking State
+
+##### Galactic
 ```sh
 ros2 topic echo /dock
 ```
+##### Humble
+```sh
+ros2 topic echo /dock_status
+```
+
 
 ### IR Docking Sensor
 ```sh

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -100,7 +100,7 @@ nav:
       - Actuators via CLI: examples/actuators-cli.md
       - Sensors via CLI: examples/sensors-cli.md
       - Navigation Apps: examples/create3_examples.md
-    - Software Releases:
+    - Firmware Releases:
       - Overview: releases/overview.md
       - G.1.1: releases/g_1_1.md
       - G.2.2: releases/g_2_2.md


### PR DESCRIPTION
Should be pretty straightforward; let me know if I missed any! Also took the opportunity to rename the "Software Releases" to "Firmware Releases" in order to try to differentiate between user software and robot firmware.