### PR TITLE
Add missing install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@ Install required dependencies:
 ```bash
 pip3 install mkdocs
 pip3 install mkdocs-material
-pip3 -r requirements.txt
+pip3 install -r requirements.txt
 ```
 
 Optionally, if you desire to generate images of STL models dynamically install:
 
 ```bash
-pip3 -r model_image_generation.txt
+pip3 install -r model_image_generation.txt
 ```
 
 


### PR DESCRIPTION
Fixes missing `install` command in the README for it to properly install the dependencies listed within other text files.