### PR TITLE
Add additional raspi3 setup instructions that fixes iRobotEducation/create3_examples#44

### DIFF
--- a/docs/setup/compute-ntp.md
+++ b/docs/setup/compute-ntp.md
@@ -34,11 +34,11 @@ If your Create® 3 and compute board have an internet connection, this is not re
 
         sudo service chrony restart
 
-1. Log into the Create® 3 web application and modify the NTP sources (as of Jul 2023 under "Beta Features") to add the following: 
+1. Log into the Create® 3 web application and modify the NTP sources (as of Jul 2023 under "Beta Features") to add the following if it does not exist: 
 
         server 192.168.186.3 iburst
 
-1. Through the Create® 3 web application, restart the NTPD server (or reboot the robot).
+1. Through the Create® 3 web application, restart the NTPD server (or reboot the robot) if you made changes in the previous step.
 
 1. Verify compute NTP server is talking to the Create® 3
 

--- a/docs/setup/compute-ntp.md
+++ b/docs/setup/compute-ntp.md
@@ -22,7 +22,6 @@ If your Create® 3 and compute board have an internet connection, this is not re
 
 1. Add the following lines after the `pool #.ubuntu.pool.ntp.org iburst maxsources #` block
 
-        server 192.168.186.2 presend 0 minpoll 0 maxpoll 0 iburst  prefer trust
         # Enable serving time to ntp clients on 192.168.186.0 subnet.
         allow 192.168.186.0/24
 
@@ -35,6 +34,12 @@ If your Create® 3 and compute board have an internet connection, this is not re
 
         sudo service chrony restart
 
+1. Log into the Create® 3 web application and modify the NTP sources (as of Jul 2023 under "Beta Features") to add the following: 
+
+        server 192.168.186.3 iburst
+
+1. Through the Create® 3 web application, restart the NTPD server (or reboot the robot).
+
 1. Verify compute NTP server is talking to the Create® 3
 
         sudo chronyc clients
@@ -44,12 +49,11 @@ If your Create® 3 and compute board have an internet connection, this is not re
         Hostname                      NTP   Drop Int IntL Last     Cmd   Drop Int  Last
         ===============================================================================
         192.168.186.2                  51      0   5   -    32       0      0   -     -
-        localhost                       0      0   -   -     -      31      0   7     4
 
 1. Note that if there is a large jump in the time, the Create® 3 may not accept it until its next reboot.
     This can be verified by checking the Create® 3 robot's log for a line like
 
         user.notice ntpd: ntpd: reply from 192.168.186.3: delay ### is too high, ignoring
-    If this happens, simply restart the robot (not just the application) via the webserver over the USB network connection.
+    If this happens, simply restart the robot (not just the application) via the webserver over the network connection.
 
 [^1]: ROS 2 is governed by Open Robotics

--- a/docs/setup/pi4galactic.md
+++ b/docs/setup/pi4galactic.md
@@ -37,6 +37,13 @@ The first boot may take a few minutes. (It may help to have a monitor and keyboa
         sudo update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
         export LANG=en_US.UTF-8
 
+1. Specify some NTP servers for time syncronization. Edit `/etc/systemd/timesyncd.conf` (`sudo nano /etc/systemd/timesyncd.conf`) to have these contents:
+
+        [Time]
+        NTP=ntp.ubuntu.com
+        FallbackNTP=0.us.pool.ntp.org 1.us.pool.ntp.org
+
+1. Run `systemctl restart systemd-timesyncd.service` to load the new NTP server configuration.
 1. Then, execute the following blocks of commands to install ROS 2[^4]:
 
         sudo apt update && sudo apt install -y curl gnupg2 lsb-release build-essential git cmake

--- a/docs/setup/pi4galactic.md
+++ b/docs/setup/pi4galactic.md
@@ -37,13 +37,13 @@ The first boot may take a few minutes. (It may help to have a monitor and keyboa
         sudo update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
         export LANG=en_US.UTF-8
 
-1. Specify some NTP servers for time syncronization. Edit `/etc/systemd/timesyncd.conf` (`sudo nano /etc/systemd/timesyncd.conf`) to have these contents:
+1. Recommended: follow the procedure to [Setup NTP on this compute board](compute-ntp.md) so the Create 3 can sync its clock.
+2. Optional: Run `timedatectl` and see if `System clock synchronized: ` says `yes`. If not, you may want setup NTP on your raspi so the clock stays accurate. To do so, specify some NTP servers for time syncronization. Edit `/etc/systemd/timesyncd.conf` (`sudo nano /etc/systemd/timesyncd.conf`) to have the below contents, then run `systemctl restart systemd-timesyncd.service` to load the new NTP server configuration. 
 
         [Time]
         NTP=ntp.ubuntu.com
         FallbackNTP=0.us.pool.ntp.org 1.us.pool.ntp.org
 
-1. Run `systemctl restart systemd-timesyncd.service` to load the new NTP server configuration.
 1. Then, execute the following blocks of commands to install ROS 2[^4]:
 
         sudo apt update && sudo apt install -y curl gnupg2 lsb-release build-essential git cmake

--- a/docs/setup/pi4humble.md
+++ b/docs/setup/pi4humble.md
@@ -60,13 +60,13 @@ The first boot may take a few minutes. (It may help to have a monitor and keyboa
         sudo update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
         export LANG=en_US.UTF-8
 
-1. Specify some NTP servers for time syncronization. Edit `/etc/systemd/timesyncd.conf` (`sudo nano /etc/systemd/timesyncd.conf`) to have these contents:
+1. Recommended: follow the procedure to [Setup NTP on this compute board](compute-ntp.md) so the Create 3 can sync its clock.
+2. Optional: Run `timedatectl` and see if `System clock synchronized: ` says `yes`. If not, you may want setup NTP on your raspi so the clock stays accurate. To do so, specify some NTP servers for time syncronization. Edit `/etc/systemd/timesyncd.conf` (`sudo nano /etc/systemd/timesyncd.conf`) to have the below contents, then run `systemctl restart systemd-timesyncd.service` to load the new NTP server configuration.
 
         [Time]
         NTP=ntp.ubuntu.com
         FallbackNTP=0.us.pool.ntp.org 1.us.pool.ntp.org
 
-1. Run `systemctl restart systemd-timesyncd.service` to load the new NTP server configuration.
 1. Then, execute the following blocks of commands to install ROS 2[^4]:
 
         sudo apt update && sudo apt install -y curl gnupg2 lsb-release build-essential git cmake

--- a/docs/setup/pi4humble.md
+++ b/docs/setup/pi4humble.md
@@ -60,6 +60,13 @@ The first boot may take a few minutes. (It may help to have a monitor and keyboa
         sudo update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
         export LANG=en_US.UTF-8
 
+1. Specify some NTP servers for time syncronization. Edit `/etc/systemd/timesyncd.conf` (`sudo nano /etc/systemd/timesyncd.conf`) to have these contents:
+
+        [Time]
+        NTP=ntp.ubuntu.com
+        FallbackNTP=0.us.pool.ntp.org 1.us.pool.ntp.org
+
+1. Run `systemctl restart systemd-timesyncd.service` to load the new NTP server configuration.
 1. Then, execute the following blocks of commands to install ROS 2[^4]:
 
         sudo apt update && sudo apt install -y curl gnupg2 lsb-release build-essential git cmake


### PR DESCRIPTION
When going through the lidar demo, I also ran into #44. The issue was indeed a mismatch of timestamps on the raspi. From a vanilla Ubuntu Raspi Server install, there aren't any NTP servers defined for synchronization, so the timestamps on the raspi were something like Mar 2023 for me, but the robot timestamps were present day.

These changes walk through adding NTP servers during raspi setup, which should allow the raspi to sync its clock and be happy.