### PR TITLE
Release G.5.2 and H.2.2

### DIFF
--- a/docs/releases/g_5_2.md
+++ b/docs/releases/g_5_2.md
@@ -1,0 +1,22 @@
+# iRobot® Create® 3 Release G.5.2
+[[Click here to download release G.5.2]](https://edu.irobot.com/create3/firmware/G.5.2)
+
+## This release is running ROS 2 Galactic with the following interface library versions:
+
+- [irobot_create_msgs - 1.2.4](https://github.com/iRobotEducation/irobot_create_msgs/tree/1.2.4)
+- [cyclonedds - 0.8.1](https://github.com/eclipse-cyclonedds/cyclonedds/tree/0.8.1)
+- [Fast-DDS - 2.3.3](https://github.com/eProsima/Fast-DDS/tree/2.3.3)
+
+## Release Overview
+For ROS 2[^1] users, this is a bugfix release.
+For iRobot® Education Bluetooth[^2] users, there are no changes.
+See below for details.
+
+## Changelog (from G.5.1)
+### ROS 2
+* Client Library
+    * Set lock free queue MAX_SEMA_SPINS = 0 [(irobotros/rclcpp#111](https://github.com/irobot-ros/rclcpp/pull/111) and [irobot-ros/events-executor#20)](https://github.com/irobot-ros/events-executor/pull/20)
+
+[^1]: ROS 2 is governed by Open Robotics.
+[^2]: The Bluetooth® word mark and logos are registered trademarks owned by Bluetooth SIG, Inc. and any use of such marks by iRobot is under license.
+[^3]: All other trademarks mentioned are the property of their respective owners.

--- a/docs/releases/g_5_2.md
+++ b/docs/releases/g_5_2.md
@@ -15,7 +15,7 @@ See below for details.
 ## Changelog (from G.5.1)
 ### ROS 2
 * Client Library
-    * Set lock free queue MAX_SEMA_SPINS = 0 [(irobotros/rclcpp#111](https://github.com/irobot-ros/rclcpp/pull/111) and [irobot-ros/events-executor#20)](https://github.com/irobot-ros/events-executor/pull/20)
+    * Set lock free queue MAX_SEMA_SPINS = 0 [(irobotros/rclcpp#111)](https://github.com/irobot-ros/rclcpp/pull/111)
 
 [^1]: ROS 2 is governed by Open Robotics.
 [^2]: The Bluetooth® word mark and logos are registered trademarks owned by Bluetooth SIG, Inc. and any use of such marks by iRobot is under license.

--- a/docs/releases/h_1_1.md
+++ b/docs/releases/h_1_1.md
@@ -11,8 +11,8 @@
 - [Fast-DDS - 2.6.4](https://github.com/eProsima/Fast-DDS/tree/2.6.4)
 
 ## Release Overview
-For iRobot® Education Bluetooth[^1] users, there are no changes.
-For ROS 2[^2] users, this release fixes a couple issues.
+For ROS 2[^1] users, this release fixes a couple issues.
+For iRobot® Education Bluetooth[^2] users, there are no changes.
 See below for details.
 
 ## Changelog (from H.1.0)

--- a/docs/releases/h_1_2.md
+++ b/docs/releases/h_1_2.md
@@ -11,8 +11,8 @@
 - [Fast-DDS - 2.6.4](https://github.com/eProsima/Fast-DDS/tree/2.6.4)
 
 ## Release Overview
-For iRobot® Education Bluetooth[^1] users, there are no changes.
-For ROS 2[^2] users, this release fixes a few issues and adds a beta feature.
+For ROS 2[^1] users, this release fixes a few issues and adds a beta feature.
+For iRobot® Education Bluetooth[^2] users, there are no changes.
 See below for details.
 
 ## Changelog (from H.1.1)

--- a/docs/releases/h_2_1.md
+++ b/docs/releases/h_2_1.md
@@ -11,8 +11,8 @@
 - [Fast-DDS - 2.6.4](https://github.com/eProsima/Fast-DDS/tree/2.6.4)
 
 ## Release Overview
-For iRobot® Education Bluetooth[^1] users, this is a bugfix release.
-For ROS 2[^2] users, this is primarily a feature release.
+For ROS 2[^1] users, this is primarily a feature release.
+For iRobot® Education Bluetooth[^2] users, this is a bugfix release.
 See below for details.
 
 ## Changelog (from H.1.2)

--- a/docs/releases/h_2_2.md
+++ b/docs/releases/h_2_2.md
@@ -1,0 +1,25 @@
+# iRobot® Create® 3 Release H.2.2
+[[Click here to download release H.2.2]](https://edu.irobot.com/create3/firmware/H.2.2)
+
+!!! warning
+    When using Fast-DDS, startup times are about 30s longer than in our Galactic release. We are working on a fix.
+
+## This release is running ROS 2 Humble with the following interface library versions:
+
+- [irobot_create_msgs - 2.1.0](https://github.com/iRobotEducation/irobot_create_msgs/tree/2.1.0)
+- [cyclonedds - 0.9.0](https://github.com/eclipse-cyclonedds/cyclonedds/tree/0.9.0)
+- [Fast-DDS - 2.6.4](https://github.com/eProsima/Fast-DDS/tree/2.6.4)
+
+## Release Overview
+For ROS 2[^1] users, this is a bugfix release.
+For iRobot® Education Bluetooth[^2] users, there are no changes.
+See below for details.
+
+## Changelog (from H.2.1)
+### ROS 2
+* Client Library
+    * Set lock free queue MAX_SEMA_SPINS = 0 [(irobotros/rclcpp#111](https://github.com/irobot-ros/rclcpp/pull/111) and [irobot-ros/events-executor#20)](https://github.com/irobot-ros/events-executor/pull/20)
+
+[^1]: ROS 2 is governed by Open Robotics.
+[^2]: The Bluetooth® word mark and logos are registered trademarks owned by Bluetooth SIG, Inc. and any use of such marks by iRobot is under license.
+[^3]: All other trademarks mentioned are the property of their respective owners.

--- a/docs/releases/h_2_2.md
+++ b/docs/releases/h_2_2.md
@@ -18,7 +18,7 @@ See below for details.
 ## Changelog (from H.2.1)
 ### ROS 2
 * Client Library
-    * Set lock free queue MAX_SEMA_SPINS = 0 [(irobotros/rclcpp#111](https://github.com/irobot-ros/rclcpp/pull/111) and [irobot-ros/events-executor#20)](https://github.com/irobot-ros/events-executor/pull/20)
+    * Set lock free queue MAX_SEMA_SPINS = 0 [(irobot-ros/events-executor#20)](https://github.com/irobot-ros/events-executor/pull/20)
 
 [^1]: ROS 2 is governed by Open Robotics.
 [^2]: The Bluetooth® word mark and logos are registered trademarks owned by Bluetooth SIG, Inc. and any use of such marks by iRobot is under license.

--- a/docs/releases/overview.md
+++ b/docs/releases/overview.md
@@ -33,14 +33,16 @@ Downloads of a particular version can be found on each individual release page.
 
 ### Humble
 
-* [H.2.1](../h_2_1) (humble-latest)
+* [H.2.2](../h_2_2) (humble-latest)
+* [H.2.1](../h_2_1)
 * [H.1.2](../h_1_2)
 * [H.1.1](../h_1_1)
 * [H.1.0](../h_1_0)
 * [H.0.0](../h_0_0)
 
 ### Galactic
-* [G.5.1](../g_5_1) (galactic-latest, latest)
+* [G.5.2](../g_5_2) (galactic-latest, latest)
+* [G.5.1](../g_5_1)
 * [G.4.5](../g_4_5)
 * [G.4.4](../g_4_4)
 * [G.4.3](../g_4_3)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -116,7 +116,7 @@ nav:
     - Firmware Releases:
       - Overview: releases/overview.md
       - Galactic:
-        - G.5.1: releases/g_5_1.md
+        - G.5.2: releases/g_5_2.md
         - Older:
           - G.1.1: releases/g_1_1.md
           - G.2.2: releases/g_2_2.md
@@ -125,10 +125,12 @@ nav:
           - G.4.3: releases/g_4_3.md
           - G.4.4: releases/g_4_4.md
           - G.4.5: releases/g_4_5.md
+          - G.5.1: releases/g_5_1.md
       - Humble:
-        - H.2.1: releases/h_2_1.md
+        - H.2.2: releases/h_2_2.md
         - Older:
           - H.0.0: releases/h_0_0.md
           - H.1.0: releases/h_1_0.md
           - H.1.1: releases/h_1_1.md
           - H.1.2: releases/h_1_2.md
+          - H.2.1: releases/h_2_1.md


### PR DESCRIPTION
This patch release reduces the CPU core utilization by 5% - 10% (for one test, median-mean of 9%, sampled over an hour).