### PR TITLE
Release G.5.3 & H.2.3

### DIFF
--- a/docs/hw/jetson_hookup.md
+++ b/docs/hw/jetson_hookup.md
@@ -21,7 +21,7 @@ Here are some hookup examples for NVIDIA® Jetson™[^2] computers.
     - Custom power cable (JST-XH to DC 5.5 mm x 2.5 mm plug)
         - [DC power plug (5.5 mm x 2.5 mm)](https://a.co/d/cfNWywP)
     - [USB data cable (**USB-C® to USB-C®**)](https://a.co/d/7H62wsI)
-    - Jetson NX-style developer kit mount ([STL file](./data/models/Compute/NVIDIA_Jetson/Adapter_Mount/C3-JetsonXavierNX-Mount.stl))
+    - Jetson NX-style developer kit mount ([STL file](./data/models/Compute/NVIDIA_Jetson/Mount_Bracket/C3-JetsonXavierNX-Mount.stl))
     - Sensor mount plate (STL file)
     - [M3 standoff/spacer x4](https://a.co/d/f1QWGB3)
     - M3 screws
@@ -43,7 +43,7 @@ This can be powered from the unregulated battery port of the Create® 3 adapter 
     - Custom power cable (JST-XH to DC 5.5 mm x 2.5 mm plug)
         - [DC power plug (5.5 mm x 2.5 mm)](https://a.co/d/cfNWywP)
     - [USB data cable (USB Micro B to USB-C®)](https://a.co/d/dnlCj1d)
-    - Jetson Xavier Developer Kit mount ([STL file](./data/models/Compute/NVIDIA_Jetson/Adapter_Mount/C3-JetsonXavierNX-Mount.stl))
+    - Jetson Xavier Developer Kit mount ([STL file](./data/models/Compute/NVIDIA_Jetson/Mount_Bracket/C3-JetsonXavierNX-Mount.stl))
     - Sensor mount plate (STL file)
     - [M3 standoff/spacer x4](https://a.co/d/f1QWGB3)
     - M3 screws

--- a/docs/releases/g_5_3.md
+++ b/docs/releases/g_5_3.md
@@ -1,0 +1,28 @@
+# iRobot® Create® 3 Release G.5.3
+[[Click here to download release G.5.3]](https://edu.irobot.com/create3/firmware/G.5.3)
+
+## This release is running ROS 2 Galactic with the following interface library versions:
+
+- [irobot_create_msgs - 1.2.4](https://github.com/iRobotEducation/irobot_create_msgs/tree/1.2.4)
+- [cyclonedds - 0.8.1](https://github.com/eclipse-cyclonedds/cyclonedds/tree/0.8.1)
+- [Fast-DDS - 2.3.3](https://github.com/eProsima/Fast-DDS/tree/2.3.3)
+
+## Release Overview
+For ROS 2[^1] users, this is a bugfix release.
+For iRobot® Education Bluetooth[^2] users, there are no changes.
+See below for details.
+
+## Changelog (from G.5.2)
+### Core Robot
+* Webserver
+    * Fix to the provisioning flow affecting some users [(#395)](https://github.com/iRobotEducation/create3_docs/issues/395)
+    * ntpd.conf is now reset upon factory reset.
+
+### ROS 2
+* Publications
+    * The `cliff_intensity` topic will no longer report values less than zero.
+    * The `kidnap_status` timestamp is now correct.
+
+[^1]: ROS 2 is governed by Open Robotics.
+[^2]: The Bluetooth® word mark and logos are registered trademarks owned by Bluetooth SIG, Inc. and any use of such marks by iRobot is under license.
+[^3]: All other trademarks mentioned are the property of their respective owners.

--- a/docs/releases/h_2_3.md
+++ b/docs/releases/h_2_3.md
@@ -1,0 +1,32 @@
+# iRobot® Create® 3 Release H.2.3
+[[Click here to download release H.2.3]](https://edu.irobot.com/create3/firmware/H.2.3)
+
+!!! warning
+    When using Fast-DDS, startup times are about 30s longer than in our Galactic release. We are working on a fix.
+
+## This release is running ROS 2 Humble with the following interface library versions:
+
+- [irobot_create_msgs - 2.1.0](https://github.com/iRobotEducation/irobot_create_msgs/tree/2.1.0)
+- [cyclonedds - 0.9.0](https://github.com/eclipse-cyclonedds/cyclonedds/tree/0.9.0)
+- [Fast-DDS - 2.6.4](https://github.com/eProsima/Fast-DDS/tree/2.6.4)
+
+## Release Overview
+For ROS 2[^1] users, this is a bugfix release.
+For iRobot® Education Bluetooth[^2] users, there are no changes.
+See below for details.
+
+## Changelog (from H.2.2)
+### Core Robot
+* Webserver
+    * Fix to the provisioning flow affecting some users [(#395)](https://github.com/iRobotEducation/create3_docs/issues/395)
+    * Factory reset now properly resets ntpd.conf.
+    * Factory reset now resets the RMW to Fast DDS (default for Humble).
+
+### ROS 2
+* Publications
+    * The `cliff_intensity` topic will no longer report values less than zero.
+    * The `kidnap_status` timestamp is now correct.
+
+[^1]: ROS 2 is governed by Open Robotics.
+[^2]: The Bluetooth® word mark and logos are registered trademarks owned by Bluetooth SIG, Inc. and any use of such marks by iRobot is under license.
+[^3]: All other trademarks mentioned are the property of their respective owners.

--- a/docs/releases/overview.md
+++ b/docs/releases/overview.md
@@ -33,7 +33,8 @@ Downloads of a particular version can be found on each individual release page.
 
 ### Humble
 
-* [H.2.2](../h_2_2) (humble-latest)
+* [H.2.3](../h_2_3) (humble-latest)
+* [H.2.2](../h_2_2)
 * [H.2.1](../h_2_1)
 * [H.1.2](../h_1_2)
 * [H.1.1](../h_1_1)
@@ -41,7 +42,8 @@ Downloads of a particular version can be found on each individual release page.
 * [H.0.0](../h_0_0)
 
 ### Galactic
-* [G.5.2](../g_5_2) (galactic-latest, latest)
+* [G.5.3](../g_5_3) (galactic-latest, latest)
+* [G.5.2](../g_5_2)
 * [G.5.1](../g_5_1)
 * [G.4.5](../g_4_5)
 * [G.4.4](../g_4_4)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -116,7 +116,7 @@ nav:
     - Firmware Releases:
       - Overview: releases/overview.md
       - Galactic:
-        - G.5.2: releases/g_5_2.md
+        - G.5.3: releases/g_5_3.md
         - Older:
           - G.1.1: releases/g_1_1.md
           - G.2.2: releases/g_2_2.md
@@ -126,11 +126,13 @@ nav:
           - G.4.4: releases/g_4_4.md
           - G.4.5: releases/g_4_5.md
           - G.5.1: releases/g_5_1.md
+          - G.5.2: releases/g_5_2.md
       - Humble:
-        - H.2.2: releases/h_2_2.md
+        - H.2.3: releases/h_2_3.md
         - Older:
           - H.0.0: releases/h_0_0.md
           - H.1.0: releases/h_1_0.md
           - H.1.1: releases/h_1_1.md
           - H.1.2: releases/h_1_2.md
           - H.2.1: releases/h_2_1.md
+          - H.2.2: releases/h_2_2.md


### PR DESCRIPTION
### Core Robot
* Webserver
    * Fix to the provisioning flow affecting some users ( fixes #395 )
    * ntpd.conf is now reset upon factory reset.
### ROS 2
* Publications
    * The `cliff_intensity` topic will no longer report values less than zero.
    * The `kidnap_status` timestamp is now correct.