### PR TITLE
Release G.5.4 / H.2.4

### DIFF
--- a/docs/hw/electrical.md
+++ b/docs/hw/electrical.md
@@ -6,21 +6,26 @@ The battery shipping with the robot is a 26 Wh, 4S Lithium Ion smart battery pac
 It will report a 0% state of charge when the total voltage of the pack reaches 12.0 V.
 It will self-protect and disconnect from any load at 10.8 V or lower.
 
-!!! attention "Notice"
-    If the robot is approaching a 0% state of charge and the application does not believe it will make it to the dock, the robot should be powered down using the `/robot_power` service.
+!!! warning "Notice"
+    If the robot is approaching a 0% state of charge and the user application does not believe it will make it to the dock, the robot should be powered down using the [`/robot_power` service](../../examples/actuators-cli/#robot-power).
+    It is recommended to return to the dock at or below about 10% state of charge in order to prevent the robot from being stranded without power.
+
+
+!!! info
+    As of software version G.5.4 (Galactic) and H.2.4 (Humble), the Create 3 robot will interally call the `/robot_power` service once the battery's state of charge dips below 2% in order to reduce the risk of tripping the battery's self-protection limits.
 
 If the battery self-protects, its internal management system may refuse to charge until it is reset.
 Resetting the battery is accomplished by removing the battery from the robot for at least fifteen minutes, at which point it should be reinstalled in the robot and the robot placed on the charger.
 
 
-!!! attention "Notice"
+!!! info
     When not overridden, the robot's light ring will flash red to indicate low battery state, at about 10% state of charge. It is recommended not to run the robot for extended periods of time in this state.
 
 Charge the battery by placing Create® 3 on the included iRobot® Home Base™ Charging Station.
 The light ring will show the state of charge and animate while the battery is charging.
 The battery will self-protect and disable the ability to charge if it charges continuously for four hours without reaching 100% state of charge.
 
-!!! attention "Notice"
+!!! danger "Notice"
     Always remove the Create® 3 robot’s battery prior to dismantling, adjusting, altering, or affecting the robot’s chassis at the risk of damaging the battery, robot, or both.
     Do not attempt to use the robot without its battery installed.
 

--- a/docs/hw/face.md
+++ b/docs/hw/face.md
@@ -30,42 +30,42 @@ The LEDs expose internal state information about the robot, but can also be over
 ### While Charging
 |  Spinning White  |  Partial White  |  Solid White  |  Pulsing Red  |
 | ----- | ----- | ----- | ------ |
-|  ![Full spinning white](data/lightring/boot.gif){: style="height:100px;width:100px"}  |  ![Partial spinning white](data/lightring/charged_spinning.gif){: style="height:100px;width:100px"}  |  ![Solid white](data/lightring/white_solid.jpg){: style="height:100px;width:100px"}  |  ![Pulsing Red](data/lightring/red_pulsing.gif){: style="height:100px;width:100px"}  |
+|  ![Full spinning white](data/lightring/boot.gif){: style="height:100%;width:100%"}  |  ![Partial spinning white](data/lightring/charged_spinning.gif){: style="height:100%;width:100%"}  |  ![Solid white](data/lightring/white_solid.jpg){: style="height:100%;width:100%"}  |  ![Pulsing Red](data/lightring/red_pulsing.gif){: style="height:100%;width:100%"}  |
 |  Robot is booting up.<br>Wait for "happy sound" to play.  |  Robot is charging<br>(Example shows 40%)  |  Robot is 100% charged  |  Battery < 10%  |
 
 ### While Idle
 |  Spinning White  |  Solid White  |  Pulsing Red  |  Solid Red  |
 | ----- | ----- | ----- | ------ |
-|  ![Full spinning white](data/lightring/boot.gif){: style="height:100px;width:100px"}  |  ![Solid white](data/lightring/white_solid.jpg){: style="height:100px;width:100px"}  |  ![Pulsing Red](data/lightring/red_pulsing.gif){: style="height:100px;width:100px"}  |  ![Solid Red](data/lightring/red_solid.jpg){: style="height:100px;width:100px"}  |
+|  ![Full spinning white](data/lightring/boot.gif){: style="height:100%;width:100%"}  |  ![Solid white](data/lightring/white_solid.jpg){: style="height:100%;width:100%"}  |  ![Pulsing Red](data/lightring/red_pulsing.gif){: style="height:100%;width:100%"}  |  ![Solid Red](data/lightring/red_solid.jpg){: style="height:100%;width:100%"}  |
 |  Robot is booting up.<br>Wait for "happy sound" to play.  |  Robot is powered on  |  Battery <10%. Place on charger.  |  Robot error. Cycle power.  |
 
 ### While Connecting to Robot Access Point
-|  Spinning Cyan  |  Solid Cyan  |
-| ----- | ----- |
-|  ![Spinning cyan](data/lightring/cyan_spinning.gif){: style="height:100px;width:100px"}  |  ![Solid cyan](data/lightring/cyan_solid.jpg){: style="height:100px;width:100px"}  |
-|  Access Point is active. <br> Select robot from device’s <br> Wi-Fi menu.  |  Device is connected to <br> robot’s Access Point page.  |
+|  Spinning Cyan  |  Solid Cyan  | | |
+| ----- | ----- | ----- | ----- |
+|  ![Spinning cyan](data/lightring/cyan_spinning.gif){: style="height:100%;width:100%"}  |  ![Solid cyan](data/lightring/cyan_solid.jpg){: style="height:100%;width:100%"}  | | |
+|  Access Point is active. <br> Select robot from device’s <br> Wi-Fi menu.  |  Device is connected to <br> robot’s Access Point page.  | | |
 
 ### While Connecting to Wi-Fi
 |  Solid Cyan  |  Spinning Cyan  |  Quick Green Flash  |  Solid White  |
 | ----- | ----- | ----- | ----- |
-|  ![Solid cyan](data/lightring/cyan_solid.jpg){: style="height:100px;width:100px"}  |  ![Spinning cyan](data/lightring/cyan_spinning.gif){: style="height:100px;width:100px"}  |  ![Green Flash](data/lightring/green_solid.jpg){: style="height:100px;width:100px"}  |  ![Solid White](data/lightring/white_solid.jpg){: style="height:100px;width:100px"}  |
+|  ![Solid cyan](data/lightring/cyan_solid.jpg){: style="height:100%;width:100%"}  |  ![Spinning cyan](data/lightring/cyan_spinning.gif){: style="height:100%;width:100%"}  |  ![Green Flash](data/lightring/green_solid.jpg){: style="height:100%;width:100%"}  |  ![Solid White](data/lightring/white_solid.jpg){: style="height:100%;width:100%"}  |
 |  Device is connected to <br> robot’s Access Point page.  |  Robot attempting to <br> connect to Wi-Fi  |  Success connecting to Wi-Fi  |  Robot successfully <br> disconnected from <br> Access Point page  |
 
 |  Yellow with Red  |  Yellow with Green  |  Yellow with Blue  |  Yellow with White  |  Solid Yellow  |
 | ----- | ----- | ----- | ----- | ----- |
-|  ![Yellow with red](data/lightring/yellow-red_solid.jpg){: style="height:100px;width:100px"}  |  ![Yellow with green](data/lightring/yellow-green_solid.jpg){: style="height:100px;width:100px"}  |  ![Yellow with blue](data/lightring/yellow-blue_solid.jpg){: style="height:100px;width:100px"}  |  ![Yellow with white](data/lightring/yellow-white_solid.jpg){: style="height:100px;width:100px"}  |  ![Solid yellow](data/lightring/yellow_solid.jpg){: style="height:100px;width:100px"}  |
+|  ![Yellow with red](data/lightring/yellow-red_solid.jpg){: style="height:100%;width:100%"}  |  ![Yellow with green](data/lightring/yellow-green_solid.jpg){: style="height:100%;width:100%"}  |  ![Yellow with blue](data/lightring/yellow-blue_solid.jpg){: style="height:100%;width:100%"}  |  ![Yellow with white](data/lightring/yellow-white_solid.jpg){: style="height:100%;width:100%"}  |  ![Solid yellow](data/lightring/yellow_solid.jpg){: style="height:100%;width:100%"}  |
 |  Failed Wi-Fi password  |  Robot cannot connect to <br> network access point | DHCP failed to obtain a valid <br> IP address before time-out. <br> Try again. |  Access point located but <br> failed association. Try again.  |  Failed to connect to Wi-Fi <br> for unknown reason  |
 
 ### While Updating Firmware
 |  Solid Cyan  |  Spinning Blue  |  Spinning White  |  Solid White  |
 | ----- | ----- | ----- | ----- |
-|  ![Solid cyan](data/lightring/cyan_solid.jpg){: style="height:100px;width:100px"}  |  ![Spinning blue](data/lightring/blue_spinning.gif){: style="height:100px;width:100px"}  |  ![Full spinning white](data/lightring/boot.gif){: style="height:100px;width:100px"}  |  ![Solid White](data/lightring/white_solid.jpg){: style="height:100px;width:100px"}  |
+|  ![Solid cyan](data/lightring/cyan_solid.jpg){: style="height:100%;width:100%"}  |  ![Spinning blue](data/lightring/blue_spinning.gif){: style="height:100%;width:100%"}  |  ![Full spinning white](data/lightring/boot.gif){: style="height:100%;width:100%"}  |  ![Solid White](data/lightring/white_solid.jpg){: style="height:100%;width:100%"}  |
 |  Device is connected to <br> robot’s Access Point page.  |  Robot downloading <br> update file  |  Robot updating firmware <br> Do not remove from dock  |  Update successful  |
 
 ### While Operating
 |  Spinning White  |  Solid White  |  Pulsing Red  |  Spinning Red  |  Half Solid Orange  | Half Solid Yellow  |
 | ----- | ----- | ----- | ----- | ----- | ----- |
-|  ![Full spinning white](data/lightring/boot.gif){: style="height:100px;width:100px"}  |  ![Solid white](data/lightring/white_solid.jpg){: style="height:100px;width:100px"}  |  ![Pulsing Red](data/lightring/red_pulsing.gif){: style="height:100px;width:100px"}  |  ![Spinning Red](data/lightring/red_spinning.gif){: style="height:100px;width:100px"}  |  ![Rear Half Orange](data/lightring/orange_half_solid.jpg){: style="height:100px;width:100px"}  |  ![Rear Half Yellow](data/lightring/yellow_half_solid.jpg){: style="height:100px;width:100px"}  |
+|  ![Full spinning white](data/lightring/boot.gif){: style="height:100%;width:100%"}  |  ![Solid white](data/lightring/white_solid.jpg){: style="height:100%;width:100%"}  |  ![Pulsing Red](data/lightring/red_pulsing.gif){: style="height:100%;width:100%"}  |  ![Spinning Red](data/lightring/red_spinning.gif){: style="height:100%;width:100%"}  |  ![Rear Half Orange](data/lightring/orange_half_solid.jpg){: style="height:100%;width:100%"}  |  ![Rear Half Yellow](data/lightring/yellow_half_solid.jpg){: style="height:100%;width:100%"}  |
 |  Robot is booting up.<br>Wait for "happy sound" to play.  |  Default light color  |  Battery < 10%  |  Battery < 3%  |  Back-up safety activated  |  Wheels disabled  |
 
 [^1]: The Bluetooth® word mark and logos are registered trademarks owned by Bluetooth SIG, Inc. and any use of such marks by iRobot is under license.

--- a/docs/hw/face.md
+++ b/docs/hw/face.md
@@ -63,10 +63,10 @@ The LEDs expose internal state information about the robot, but can also be over
 |  Device is connected to <br> robot’s Access Point page.  |  Robot downloading <br> update file  |  Robot updating firmware <br> Do not remove from dock  |  Update successful  |
 
 ### While Operating
-|  Spinning White  |  Solid White  |  Pulsing Red  |  Half Solid Orange  | Half Solid Yellow  |
-| ----- | ----- | ----- | ----- | ----- |
-|  ![Full spinning white](data/lightring/boot.gif){: style="height:100px;width:100px"}  |  ![Solid white](data/lightring/white_solid.jpg){: style="height:100px;width:100px"}  |  ![Pulsing Red](data/lightring/red_pulsing.gif){: style="height:100px;width:100px"}  |  ![Rear Half Orange](data/lightring/orange_half_solid.jpg){: style="height:100px;width:100px"}  |  ![Rear Half Yellow](data/lightring/yellow_half_solid.jpg){: style="height:100px;width:100px"}  |
-|  Robot is booting up.<br>Wait for "happy sound" to play.  |  Default light color  |  Battery <10%.  |  Back-up safety activated  |  Wheels disabled  |
+|  Spinning White  |  Solid White  |  Pulsing Red  |  Spinning Red  |  Half Solid Orange  | Half Solid Yellow  |
+| ----- | ----- | ----- | ----- | ----- | ----- |
+|  ![Full spinning white](data/lightring/boot.gif){: style="height:100px;width:100px"}  |  ![Solid white](data/lightring/white_solid.jpg){: style="height:100px;width:100px"}  |  ![Pulsing Red](data/lightring/red_pulsing.gif){: style="height:100px;width:100px"}  |  ![Spinning Red](data/lightring/red_spinning.gif){: style="height:100px;width:100px"}  |  ![Rear Half Orange](data/lightring/orange_half_solid.jpg){: style="height:100px;width:100px"}  |  ![Rear Half Yellow](data/lightring/yellow_half_solid.jpg){: style="height:100px;width:100px"}  |
+|  Robot is booting up.<br>Wait for "happy sound" to play.  |  Default light color  |  Battery < 10%  |  Battery < 3%  |  Back-up safety activated  |  Wheels disabled  |
 
 [^1]: The Bluetooth® word mark and logos are registered trademarks owned by Bluetooth SIG, Inc. and any use of such marks by iRobot is under license.
 [^2]: All other trademarks mentioned are the property of their respective owners.

--- a/docs/hw/overview.md
+++ b/docs/hw/overview.md
@@ -3,12 +3,12 @@ The Create® 3 is based on the Roomba®, a robot vacuum cleaner.
 Its sensors, actuators, and compact design are capable of navigating and mapping a the whole floor of a home or office space.
 The robot also ships with an iRobot® Home Base™ Charging Station.
 
-![Create® 3 from its above-front-right, next to its dock.](data/front_iso.jpg "Robot Front")
+![Create® 3 from its above-front-right, next to its dock.](data/front_iso.jpg "Robot Front")<br>
 The front of the robot features a multizone bumper with seven pairs of IR proximity sensors, which can be used to detect obstacles.
 The top of the robot contains three buttons which can all be overloaded by a ROS 2 application (only the • and •• buttons can be overloaded in the iRobot Coding app.)
 The power button features a ring of six RGB LEDs for indication.
 
-![Create® 3 from its above-rear-left, with the top cover and cargo bay removed.](data/rear_iso.jpg "Robot Rear")
+![Create® 3 from its above-rear-left, with the top cover and cargo bay removed.](data/rear_iso.jpg "Robot Rear")<br>
 The faceplate and cargo bay of the robot feature a regular hole pattern for attaching payloads and can be removed without tools for quick prototyping.
 There are two cable passthroughs: one on the top edge of the cargo bay which is good for quick prototyping and one that penetrates the top cover and faceplate which is useful for keeping wires within the radius of the robot.
 More information on these features can be found on the [Mechanical](../mechanical/) page.
@@ -16,7 +16,7 @@ More information on these features can be found on the [Mechanical](../mechanica
 Also visible with the faceplate removed is the adapter board, which is used to interface to external computers either through Bluetooth®[^1] or via USB-C®[^2].
 More information on this board is available on the [Electrical](../electrical/) page.
 
-![Create® 3 from a bottom view, with the cargo bay removed.](data/bottom.jpg "Robot Bottom")
+![Create® 3 from a bottom view, with the cargo bay removed.](data/bottom.jpg "Robot Bottom")<br>
 The bottom of the robot includes four cliff sensors to keep the robot on solid ground, a front caster (by default, the robot's center of gravity is forward of the center axis), charging contacts, two wheels with current sensors and encoders, and an optical odometry sensor.
 Not visible is the robot's IMU, which is used with the optical odometry sensor and wheel encoders to generate a fused odometry estimate.
 

--- a/docs/releases/g_5_4.md
+++ b/docs/releases/g_5_4.md
@@ -1,0 +1,29 @@
+# iRobot® Create® 3 Release G.5.4
+[[Click here to download release G.5.4]](https://edu.irobot.com/create3/firmware/G.5.4)
+
+## This release is running ROS 2 Galactic with the following interface library versions:
+
+- [irobot_create_msgs - 1.2.4](https://github.com/iRobotEducation/irobot_create_msgs/tree/1.2.4)
+- [cyclonedds - 0.8.1](https://github.com/eclipse-cyclonedds/cyclonedds/tree/0.8.1)
+- [Fast-DDS - 2.3.3](https://github.com/eProsima/Fast-DDS/tree/2.3.3)
+
+## Release Overview
+For ROS 2[^1] users, this is a bugfix release.
+For iRobot® Education Bluetooth[^2] users, there are no changes.
+See below for details.
+
+## Changelog (from G.5.3)
+### Core Robot
+* Webserver
+    * Add [beta feature](../../webserver/forget-wifi/) to disconnect from `wlan0` and forget the SSID [(#110)](https://github.com/iRobotEducation/create3_docs/issues/110)
+* Power Management
+    * Robot will now change its light ring to "spinning red" when the battery level dips below 3%, and will explicitly call the `/robot_power` service when it falls below 2%.
+
+### ROS 2
+* Actions
+    * The `/rotate_angle` action no longer accepts overriding goals; an ongoing goal must be completed (successfully or unsuccessfully) before a new goal will be accepted. [(#351)](https://github.com/iRobotEducation/create3_docs/issues/351)
+    * Improve reliability of robot docking and undocking.
+
+[^1]: ROS 2 is governed by Open Robotics.
+[^2]: The Bluetooth® word mark and logos are registered trademarks owned by Bluetooth SIG, Inc. and any use of such marks by iRobot is under license.
+[^3]: All other trademarks mentioned are the property of their respective owners.

--- a/docs/releases/h_2_4.md
+++ b/docs/releases/h_2_4.md
@@ -1,0 +1,32 @@
+# iRobot® Create® 3 Release H.2.4
+[[Click here to download release H.2.4]](https://edu.irobot.com/create3/firmware/H.2.4)
+
+!!! warning
+    When using Fast-DDS, startup times are about 30s longer than in our Galactic release. We are working on a fix.
+
+## This release is running ROS 2 Humble with the following interface library versions:
+
+- [irobot_create_msgs - 2.1.0](https://github.com/iRobotEducation/irobot_create_msgs/tree/2.1.0)
+- [cyclonedds - 0.9.0](https://github.com/eclipse-cyclonedds/cyclonedds/tree/0.9.0)
+- [Fast-DDS - 2.6.4](https://github.com/eProsima/Fast-DDS/tree/2.6.4)
+
+## Release Overview
+For ROS 2[^1] users, this is a bugfix release.
+For iRobot® Education Bluetooth[^2] users, there are no changes.
+See below for details.
+
+## Changelog (from H.2.3)
+### Core Robot
+* Webserver
+    * Add [beta feature](../../webserver/forget-wifi/) to disconnect from `wlan0` and forget the SSID [(#110)](https://github.com/iRobotEducation/create3_docs/issues/110)
+* Power Management
+    * Robot will now change its light ring to "spinning red" when the battery level dips below 3%, and will explicitly call the `/robot_power` service when it falls below 2%.
+
+### ROS 2
+* Actions
+    * The `/rotate_angle` action no longer accepts overriding goals; an ongoing goal must be completed (successfully or unsuccessfully) before a new goal will be accepted. [(#351)](https://github.com/iRobotEducation/create3_docs/issues/351)
+    * Improve reliability of robot docking and undocking.
+
+[^1]: ROS 2 is governed by Open Robotics.
+[^2]: The Bluetooth® word mark and logos are registered trademarks owned by Bluetooth SIG, Inc. and any use of such marks by iRobot is under license.
+[^3]: All other trademarks mentioned are the property of their respective owners.

--- a/docs/releases/overview.md
+++ b/docs/releases/overview.md
@@ -40,7 +40,7 @@ Downloads of a particular version can be found on each individual release page.
 * [H.0.0](../h_0_0)
 
 ### Galactic
-* [G.5.3](../g_5_4) (galactic-latest, latest)
+* [G.5.4](../g_5_4) (galactic-latest, latest)
 * [G.5.3](../g_5_3)
 * [G.5.2](../g_5_2)
 * [G.5.1](../g_5_1)

--- a/docs/releases/overview.md
+++ b/docs/releases/overview.md
@@ -30,7 +30,8 @@ Downloads of a particular version can be found on each individual release page.
 
 ### Humble
 
-* [H.2.3](../h_2_3) (humble-latest)
+* [H.2.4](../h_2_4) (humble-latest)
+* [H.2.3](../h_2_3)
 * [H.2.2](../h_2_2)
 * [H.2.1](../h_2_1)
 * [H.1.2](../h_1_2)
@@ -39,7 +40,8 @@ Downloads of a particular version can be found on each individual release page.
 * [H.0.0](../h_0_0)
 
 ### Galactic
-* [G.5.3](../g_5_3) (galactic-latest, latest)
+* [G.5.3](../g_5_4) (galactic-latest, latest)
+* [G.5.3](../g_5_3)
 * [G.5.2](../g_5_2)
 * [G.5.1](../g_5_1)
 * [G.4.5](../g_4_5)

--- a/docs/stylesheets/irobot-palette.css
+++ b/docs/stylesheets/irobot-palette.css
@@ -7,18 +7,18 @@
     --md-default-bg-color--light:        hsla(0, 0%, 100%, 0.7);
     --md-default-bg-color--lighter:      hsla(0, 0%, 100%, 0.3);
     --md-default-bg-color--lightest:     hsla(0, 0%, 100%, 0.12);
-  
+
     --md-primary-fg-color:               #6CB86A;
     --md-primary-fg-color--light:        #ECB7B7;
     --md-primary-fg-color--dark:         #90030C;
     --md-primary-bg-color:               hsla(0, 0%, 100%, 1);
     --md-primary-bg-color--light:        hsla(0, 0%, 100%, 0.7);
-  
+
     --md-accent-fg-color:                #e95c67;
     --md-accent-fg-color--transparent:   #e95c67;
     --md-accent-bg-color:                hsla(0, 0%, 100%, 1);
     --md-accent-bg-color--light:         hsla(0, 0%, 100%, 0.7);
-  
+
 
     --md-code-fg-color:                hsla(200, 18%, 26%, 1);
     --md-code-bg-color:                hsla(0, 0%, 96%, 1);
@@ -60,4 +60,8 @@
     --md-footer-fg-color--lighter:     hsla(0, 0%, 100%, 0.3);
     --md-footer-bg-color:              hsla(0, 0%, 0%, 0.87);
     --md-footer-bg-color--dark:        hsla(0, 0%, 0%, 0.32);
+  }
+
+  .md-grid {
+    max-width: 85%;
   }

--- a/docs/webserver/forget-wifi.md
+++ b/docs/webserver/forget-wifi.md
@@ -1,0 +1,14 @@
+# iRobot® Create® 3 Webserver - Forget Wi-Fi Network
+The "Forget Wi-Fi Network" beta menu option of the Create® 3 webserver instructs the Create® 3 robot to forget about and disconnect from any Wi-Fi networks to which it had been connected.
+
+!!!warning
+    Please note that this is a beta feature, and as such is not supported by the customer service team.
+    Please exercise caution, as improper use of beta features may result in an inoperable robot.
+
+Selecting the "Forget Wi-Fi Network" option will spawn a pop-up requesting confirmation.
+Once confirmed, the robot will forget about any SSIDs to which it has connected, and to immediately disconnect from the `wlan0` inteface if it is currently connected.
+If this command is issued over `wlan0`, it will be necessary to communicate with the robot either in AP mode or using Ethernet-over-USB.
+
+This feature can also be accessed by sending a POST to `/api/forget-wifi`.
+
+[^1]: All trademarks mentioned are the property of their respective owners.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -74,6 +74,7 @@ nav:
         - Restart ntpd: webserver/restart-ntpd.md
         - Set Wired Subnet: webserver/set-wired-subnet.md
         - Override RMW Profile: webserver/rmw-profile-override.md
+        - Forget Wi-Fi Network: webserver/forget-wifi.md
       - About: webserver/about.md
     - Setup:
       - Connect to Wi-Fi: setup/provision.md
@@ -116,7 +117,7 @@ nav:
     - Firmware Releases:
       - Overview: releases/overview.md
       - Galactic:
-        - G.5.3: releases/g_5_3.md
+        - G.5.4: releases/g_5_4.md
         - Older:
           - G.1.1: releases/g_1_1.md
           - G.2.2: releases/g_2_2.md
@@ -127,8 +128,9 @@ nav:
           - G.4.5: releases/g_4_5.md
           - G.5.1: releases/g_5_1.md
           - G.5.2: releases/g_5_2.md
+          - G.5.3: releases/g_5_3.md
       - Humble:
-        - H.2.3: releases/h_2_3.md
+        - H.2.4: releases/h_2_4.md
         - Older:
           - H.0.0: releases/h_0_0.md
           - H.1.0: releases/h_1_0.md
@@ -136,3 +138,4 @@ nav:
           - H.1.2: releases/h_1_2.md
           - H.2.1: releases/h_2_1.md
           - H.2.2: releases/h_2_2.md
+          - H.2.3: releases/h_2_3.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -33,7 +33,7 @@ extra:
     provider: google
     property: G-9QX6GHMSD7
 
-copyright: Copyright &copy; 2021-2023 iRobot Corporation. ​​All Rights Reserved.
+copyright: Copyright &copy; 2021-2024 iRobot Corporation. ​​All Rights Reserved.
 
 markdown_extensions:
   - admonition


### PR DESCRIPTION
# Changelog (from G.5.3/H.2.3)
## Core Robot
### Webserver
* Add beta feature to disconnect from wlan0 and forget the SSID (#110)
### Power Management
* Robot will now change its light ring to "spinning red" when the battery level dips below 3%, and will explicitly call the /robot_power service when it falls below 2%.
## ROS 2
### Actions
* The /rotate_angle action no longer accepts overriding goals; an ongoing goal must be completed (successfully or unsuccessfully) before a new goal will be accepted. (#351)
* Improve reliability of robot docking and undocking.