### PR TITLE
Release H.2.6

### DIFF
--- a/docs/releases/h_2_6.md
+++ b/docs/releases/h_2_6.md
@@ -1,0 +1,26 @@
+# iRobot® Create® 3 Release H.2.6
+[[Click here to download release H.2.6]](https://edu.irobot.com/create3/firmware/H.2.6)
+
+!!! warning
+    When using Fast-DDS, startup times are about 30s longer than in our Galactic release.
+
+## This release is running ROS 2 Humble with the following interface library versions:
+
+- [irobot_create_msgs - 2.1.0](https://github.com/iRobotEducation/irobot_create_msgs/tree/2.1.0)
+- [cyclonedds - 0.10.3](https://github.com/eclipse-cyclonedds/cyclonedds/tree/0.10.3)
+- [Fast-DDS - 2.6.4](https://github.com/eProsima/Fast-DDS/tree/2.6.4)
+
+## Release Overview
+For ROS 2[^1] users, this is a bugfix release.
+For iRobot® Education Bluetooth[^2] users, there are no changes.
+See below for details.
+
+## Changelog (from H.2.5)
+### ROS 2
+* Parameters
+    * Robot now sets `max_speed` parameter properly when `safety_override = full` is set in application configuration [(#558)](https://github.com/iRobotEducation/create3_docs/issues/558)
+
+
+[^1]: ROS 2 is governed by Open Robotics.
+[^2]: The Bluetooth® word mark and logos are registered trademarks owned by Bluetooth SIG, Inc. and any use of such marks by iRobot is under license.
+[^3]: All other trademarks mentioned are the property of their respective owners.

--- a/docs/releases/h_2_6.md
+++ b/docs/releases/h_2_6.md
@@ -15,6 +15,9 @@ For ROS 2[^1] users, this is a bugfix release.
 For iRobot® Education Bluetooth[^2] users, there are no changes.
 See below for details.
 
+!!! important
+    There were quite a few changes in H.2.5; it is recommended to also read [that changelog](../h_2_5).
+
 ## Changelog (from H.2.5)
 ### ROS 2
 * Parameters

--- a/docs/releases/overview.md
+++ b/docs/releases/overview.md
@@ -29,7 +29,8 @@ Downloads of a particular version can be found on each individual release page.
 ## Releases
 
 ### Humble
-* [H.2.5](../h_2_5) (humble-latest, latest)
+* [H.2.6](../h_2_6) (humble-latest, latest)
+* [H.2.5](../h_2_5)
 * [H.2.4](../h_2_4)
 * [H.2.3](../h_2_3)
 * [H.2.2](../h_2_2)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -132,7 +132,7 @@ nav:
           - G.5.2: releases/g_5_2.md
           - G.5.3: releases/g_5_3.md
       - Humble:
-        - H.2.5: releases/h_2_5.md
+        - H.2.6: releases/h_2_6.md
         - Older:
           - H.0.0: releases/h_0_0.md
           - H.1.0: releases/h_1_0.md
@@ -142,3 +142,4 @@ nav:
           - H.2.2: releases/h_2_2.md
           - H.2.3: releases/h_2_3.md
           - H.2.4: releases/h_2_4.md
+          - H.2.5: releases/h_2_5.md


### PR DESCRIPTION
Bugfix release!

Robot now sets `max_speed` parameter properly when `safety_override = full` is set in application configuration ( closes #558 )