### PR TITLE
Release I.0.0

### DIFF
--- a/docs/releases/i_0_0.md
+++ b/docs/releases/i_0_0.md
@@ -1,0 +1,30 @@
+# iRobot® Create® 3 Release I.0.0
+[[Click here to download release I.0.0.CycloneDDS]](https://github.com/iRobotEducation/create3_docs/releases/download/I.0.0/Create3-I.0.0.CycloneDDS.swu)
+[[Click here to download release I.0.0.FastDDS]](https://github.com/iRobotEducation/create3_docs/releases/download/I.0.0/Create3-I.0.0.FastDDS.swu)
+
+!!! warning
+    Be sure to download the correct release for your choice of middleware.
+
+## This release is running ROS 2 Iron with the following interface library versions:
+
+- [irobot_create_msgs - 2.1.0](https://github.com/iRobotEducation/irobot_create_msgs/tree/2.1.0)
+- [cyclonedds - 0.10.3](https://github.com/eclipse-cyclonedds/cyclonedds/tree/0.10.3)
+- [Fast-DDS - 2.10.1](https://github.com/eProsima/Fast-DDS/tree/2.10.1)
+
+## Release Overview
+For ROS 2[^1] users, this is a feature release, and our first upgrade to ROS 2 Iron.
+For iRobot® Education Bluetooth[^2] users, there are no changes.
+See below for details.
+
+!!! note
+    In testing, this release appears to be fully compatible with ROS 2 Jazzy, as well. Please be sure to let us know if you run into any [issues](https://github.com/iRobotEducation/create3_docs/issues).
+
+## Changelog (from H.2.6)
+### ROS 2
+* Topics
+    * The robot can now be tele-operated via `geometry_msgs/msg/TwistStamped` messages on the `cmd_vel_stamped` topic. (You may also continue to use the `cmd_vel` topic; don't use both at the same time.)
+
+
+[^1]: ROS 2 is governed by Open Robotics.
+[^2]: The Bluetooth® word mark and logos are registered trademarks owned by Bluetooth SIG, Inc. and any use of such marks by iRobot is under license.
+[^3]: All other trademarks mentioned are the property of their respective owners.

--- a/docs/releases/overview.md
+++ b/docs/releases/overview.md
@@ -19,6 +19,8 @@ One exception is that beta features may be added in minor releases.
 The latest stable release can be found at
 [http://edu.irobot.com/create3-latest-fw](http://edu.irobot.com/create3-latest-fw).
 
+The latest stable Iron release can be found at
+[http://edu.irobot.com/create3-iron-latest-fw](http://edu.irobot.com/create3-iron-latest-fw).
 The latest stable Humble release can be found at
 [http://edu.irobot.com/create3-humble-latest-fw](http://edu.irobot.com/create3-humble-latest-fw).
 The latest stable Galactic release can be found at
@@ -28,8 +30,11 @@ Downloads of a particular version can be found on each individual release page.
 
 ## Releases
 
+### Iron
+* [I.0.0](../i_0_0) (iron-latest, latest)
+
 ### Humble
-* [H.2.6](../h_2_6) (humble-latest, latest)
+* [H.2.6](../h_2_6) (humble-latest)
 * [H.2.5](../h_2_5)
 * [H.2.4](../h_2_4)
 * [H.2.3](../h_2_3)

--- a/docs/setup/xml-config.md
+++ b/docs/setup/xml-config.md
@@ -2,6 +2,8 @@
 
 ROS 2[^1] is built on top of DDS/RTPS as its middleware, which provides advanced networking features such as: discovery, serialization and transportation.  This **R**OS 2 **m**iddle**w**are is abbreviated **RMW** for short.
 
+The middleware running on the robot can be selected using the [Application Configuration](../webserver/application.md) page on the webserver. Note that the choice of middleware available may be restricted by the firmware installed on your robot; check the [releases](https://github.com/iRobotEducation/create3_docs/releases) for more details on available firmware.
+
 This page contains some examples that may be useful when interacting with the iRobot® Create® 3.
 
 !!! important

--- a/docs/webserver/application.md
+++ b/docs/webserver/application.md
@@ -26,6 +26,8 @@ Further details on these settings can be found in the official ROS 2 documentati
 For robots running Galactic >= G.4 and Humble >= H.1, when Fast-DDS is selected as the RMW, it is possible to direct the robot to use an offboard Fast-DDS Discovery server, as well.
 Further details on the Fast-DDS Discovery Server can be found [here](https://fast-dds.docs.eprosima.com/en/latest/fastdds/ros2/discovery_server/ros2_discovery_server.html).
 
+When running Create 3 firmware for Iron, only one middleware selection is available at a time; to switch middleware, it is necessary to install the matching firmware.
+
 ### Application ROS 2 Parameters File
 This is a raw yaml file used for configuring ROS 2 parameters.
 The web server will not validate this yaml file; setting it incorrectly may cause the application to fail to start properly.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -162,4 +162,6 @@ nav:
           - H.2.3: releases/h_2_3.md
           - H.2.4: releases/h_2_4.md
           - H.2.5: releases/h_2_5.md
+      - Iron:
+        - I.0.0: releases/i_0_0.md
     - FAQ: faq/faq.md


### PR DESCRIPTION
## Release Overview
For ROS 2[^1] users, this is a feature release, and our first upgrade to ROS 2 Iron.
For iRobot® Education Bluetooth[^2] users, there are no changes.
See below for details.

Note: In testing, this release appears to be fully compatible with ROS 2 Jazzy, as well. Please be sure to let us know if you run into any [issues](https://github.com/iRobotEducation/create3_docs/issues).

## Changelog (from H.2.6)
### ROS 2
* Topics
    * The robot can now be tele-operated via `geometry_msgs/msg/TwistStamped` messages on the `cmd_vel_stamped` topic. (You may also continue to use the `cmd_vel` topic; don't use both at the same time.)


[^1]: ROS 2 is governed by Open Robotics.
[^2]: The Bluetooth® word mark and logos are registered trademarks owned by Bluetooth SIG, Inc. and any use of such marks by iRobot is under license.
[^3]: All other trademarks mentioned are the property of their respective owners.